### PR TITLE
feat: complete TASK_046 - Fix GitHub Build Version Numbers

### DIFF
--- a/.claude/plans/046.md
+++ b/.claude/plans/046.md
@@ -1,0 +1,36 @@
+# Plan: 046
+
+Captured: 2025-09-14T01:21:14.980Z
+
+## Fix GitHub Build Version Numbers (Simplified)
+
+### Problem
+The binaries built by GitHub Actions show version `1.0.0` (hardcoded) instead of the actual release version (e.g., `1.11.0`).
+
+### Solution
+Use semantic-release's environment variables to inject the version directly at build time, without updating package.json.
+
+### Implementation Steps
+
+1. **Update `src/cli/index.ts`** to use build-time injected version:
+   ```typescript
+   // Version injected at build time, fallback for local development
+   const VERSION = process.env.BUILD_VERSION || '1.0.0-dev';
+   ```
+
+2. **Update `.releaserc.json`** to pass version during build:
+   - Modify the exec plugin's `prepareCmd` to use `--define` flag
+   - Change from: `"prepareCmd": "bun run build:cross-platform"`
+   - Change to: `"prepareCmd": "bun build src/cli/index.ts --compile --target=bun-linux-x64 --define BUILD_VERSION='\"${nextRelease.version}\"' --outfile dist/cc-track-linux && bun build src/cli/index.ts --compile --target=bun-windows-x64 --define BUILD_VERSION='\"${nextRelease.version}\"' --outfile dist/cc-track-windows.exe"`
+
+### Benefits
+- No package.json updates needed
+- No commits required during release
+- Release binaries show correct version
+- Local builds show "1.0.0-dev" to distinguish from releases
+- Simple, single-file change approach
+
+### Testing
+- Build locally: `bun run build` will show "1.0.0-dev"
+- Build with version: `bun build src/cli/index.ts --compile --define BUILD_VERSION='"test"' --outfile dist/test && dist/test --version` will show "test"
+- Next GitHub release will automatically embed the correct version

--- a/.claude/tasks/TASK_046.md
+++ b/.claude/tasks/TASK_046.md
@@ -7,12 +7,12 @@
 **Task ID:** 046
 
 ## Requirements
-- [ ] Update `src/cli/index.ts` to use build-time injected version with fallback
-- [ ] Modify `.releaserc.json` exec plugin's `prepareCmd` to use `--define` flag for version injection
-- [ ] Ensure local builds show "1.0.0-dev" to distinguish from releases
-- [ ] Ensure release binaries show correct semantic version
-- [ ] Test local build shows development version
-- [ ] Test manual build with version injection works correctly
+- [x] Update `src/cli/index.ts` to use build-time injected version with fallback
+- [x] Modify `.releaserc.json` exec plugin's `prepareCmd` to use `--define` flag for version injection
+- [x] Ensure local builds show "1.0.0-dev" to distinguish from releases
+- [x] Ensure release binaries show correct semantic version
+- [x] Test local build shows development version
+- [x] Test manual build with version injection works correctly
 
 ## Success Criteria
 - Local builds (`bun run build`) show "1.0.0-dev" version
@@ -25,18 +25,28 @@
 Use Bun's `--define` flag to inject `BUILD_VERSION` environment variable at compile time. Modify the CLI to read from `process.env.BUILD_VERSION` with fallback to development version. Update semantic-release configuration to pass the version during the prepare step using `--define BUILD_VERSION='"${nextRelease.version}"'`.
 
 ## Current Focus
-Update `src/cli/index.ts` to implement version injection pattern with environment variable fallback.
+Task completed - version injection successfully implemented.
 
 ## Open Questions & Blockers
-- Need to verify current structure of `src/cli/index.ts` and how version is currently handled
-- Need to confirm current `.releaserc.json` configuration and exec plugin setup
-- Should verify Bun's `--define` flag syntax and behavior
+None - all issues resolved.
 
 ## Next Steps
-1. Examine current `src/cli/index.ts` file structure and version handling
-2. Update version constant to use `process.env.BUILD_VERSION` with fallback
-3. Locate and update `.releaserc.json` prepareCmd configuration
-4. Test local build and manual version injection
+Task is complete and ready for the next GitHub release to test the implementation.
+
+## Recent Progress
+
+Successfully implemented build-time version injection for GitHub releases:
+
+1. **Updated `src/cli/index.ts`**: Changed hardcoded version to use `process.env.BUILD_VERSION || '1.0.0-dev'`, allowing build-time injection with local development fallback.
+
+2. **Fixed `.releaserc.json`**: Updated the exec plugin's `prepareCmd` to inject version using Bun's `--define` flag with the correct syntax: `--define 'process.env.BUILD_VERSION="${nextRelease.version}"'`
+
+3. **Verified functionality**:
+   - Local builds show `1.0.0-dev` as expected
+   - Manual test with `--define 'process.env.BUILD_VERSION="2.0.0-test"'` correctly shows the injected version
+   - The solution avoids package.json updates and extra commits during release
+
+The key discovery was that Bun's `--define` flag requires the full `process.env.BUILD_VERSION` path, not just `BUILD_VERSION`. This ensures the next GitHub release will properly embed version numbers in the compiled binaries.
 
 <!-- github_issue: 33 -->
 <!-- github_url: https://github.com/cahaseler/cc-track/issues/33 -->

--- a/.claude/tasks/TASK_046.md
+++ b/.claude/tasks/TASK_046.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Update the build process to inject the actual release version into binaries instead of showing hardcoded "1.0.0", using semantic-release environment variables at build time.
 
-**Status:** planning
+**Status:** completed
 **Started:** 2025-09-14 21:21
 **Task ID:** 046
 
@@ -25,7 +25,8 @@
 Use Bun's `--define` flag to inject `BUILD_VERSION` environment variable at compile time. Modify the CLI to read from `process.env.BUILD_VERSION` with fallback to development version. Update semantic-release configuration to pass the version during the prepare step using `--define BUILD_VERSION='"${nextRelease.version}"'`.
 
 ## Current Focus
-Task completed - version injection successfully implemented.
+
+Task completed on 2025-09-14
 
 ## Open Questions & Blockers
 None - all issues resolved.

--- a/.claude/tasks/TASK_046.md
+++ b/.claude/tasks/TASK_046.md
@@ -1,0 +1,43 @@
+# Fix GitHub Build Version Numbers
+
+**Purpose:** Update the build process to inject the actual release version into binaries instead of showing hardcoded "1.0.0", using semantic-release environment variables at build time.
+
+**Status:** planning
+**Started:** 2025-09-14 21:21
+**Task ID:** 046
+
+## Requirements
+- [ ] Update `src/cli/index.ts` to use build-time injected version with fallback
+- [ ] Modify `.releaserc.json` exec plugin's `prepareCmd` to use `--define` flag for version injection
+- [ ] Ensure local builds show "1.0.0-dev" to distinguish from releases
+- [ ] Ensure release binaries show correct semantic version
+- [ ] Test local build shows development version
+- [ ] Test manual build with version injection works correctly
+
+## Success Criteria
+- Local builds (`bun run build`) show "1.0.0-dev" version
+- Manual version injection test works: `bun build src/cli/index.ts --compile --define BUILD_VERSION='"test"' --outfile dist/test && dist/test --version` shows "test"
+- Next GitHub release automatically embeds correct version in binaries
+- No package.json updates required during release process
+- No additional commits needed during release
+
+## Technical Approach
+Use Bun's `--define` flag to inject `BUILD_VERSION` environment variable at compile time. Modify the CLI to read from `process.env.BUILD_VERSION` with fallback to development version. Update semantic-release configuration to pass the version during the prepare step using `--define BUILD_VERSION='"${nextRelease.version}"'`.
+
+## Current Focus
+Update `src/cli/index.ts` to implement version injection pattern with environment variable fallback.
+
+## Open Questions & Blockers
+- Need to verify current structure of `src/cli/index.ts` and how version is currently handled
+- Need to confirm current `.releaserc.json` configuration and exec plugin setup
+- Should verify Bun's `--define` flag syntax and behavior
+
+## Next Steps
+1. Examine current `src/cli/index.ts` file structure and version handling
+2. Update version constant to use `process.env.BUILD_VERSION` with fallback
+3. Locate and update `.releaserc.json` prepareCmd configuration
+4. Test local build and manual version injection
+
+<!-- github_issue: 33 -->
+<!-- github_url: https://github.com/cahaseler/cc-track/issues/33 -->
+<!-- issue_branch: 33-fix-github-build-version-numbers -->

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "bun run build:cross-platform"
+        "prepareCmd": "bun build src/cli/index.ts --compile --target=bun-linux-x64 --define 'process.env.BUILD_VERSION=\"${nextRelease.version}\"' --outfile dist/cc-track-linux && bun build src/cli/index.ts --compile --target=bun-windows-x64 --define 'process.env.BUILD_VERSION=\"${nextRelease.version}\"' --outfile dist/cc-track-windows.exe"
       }
     ],
     [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Project: cc-track
 
 ## Active Task
-@.claude/tasks/TASK_046.md
+@.claude/no_active_task.md
 <!-- IMPORTANT: Never edit this file to mark a task complete. Use /complete-task command instead. -->
 
 ## Product Vision

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Project: cc-track
 
 ## Active Task
-@.claude/no_active_task.md
+@.claude/tasks/TASK_046.md
 <!-- IMPORTANT: Never edit this file to mark a task complete. Use /complete-task command instead. -->
 
 ## Product Vision

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,8 +10,8 @@ import { parseLogsCommand } from '../commands/parse-logs';
 import { createPrepareCompletionCommand } from '../commands/prepare-completion';
 import { statuslineCommand } from '../commands/statusline';
 
-// Version is hardcoded for compiled binary
-const VERSION = '1.0.0';
+// Version injected at build time, fallback for local development
+const VERSION = process.env.BUILD_VERSION || '1.0.0-dev';
 
 // Create main program
 const program = new Command();


### PR DESCRIPTION
## Summary
Completes TASK_046: Fix GitHub Build Version Numbers

This PR fixes the issue where GitHub release binaries were showing hardcoded version '1.0.0' instead of the actual release version (e.g., '1.11.0').

## What Was Delivered
- Dynamic version injection at build time for release binaries
- Development version indicator ('1.0.0-dev') for local builds
- No package.json updates required during releases
- No additional commits needed during release process

## Technical Implementation
- Modified `src/cli/index.ts` to read version from `process.env.BUILD_VERSION` with fallback to '1.0.0-dev'
- Updated `.releaserc.json` to inject version using Bun's `--define` flag during semantic-release build
- Used `--define 'process.env.BUILD_VERSION="${nextRelease.version}"'` syntax for proper environment variable injection
- Maintained backward compatibility for local development builds

## Testing
- ✅ Local build shows '1.0.0-dev': `bun run build && ./dist/cc-track --version`
- ✅ Manual version injection works: `bun build src/cli/index.ts --compile --define 'process.env.BUILD_VERSION="2.0.0-test"' --outfile dist/test-version`
- ✅ Downloaded and tested v1.11.0 release binary (currently shows '1.0.0', will be fixed in next release)
- ⏳ Next GitHub release will automatically embed correct version number

## Impact
The next GitHub release and all subsequent releases will correctly report their version numbers, improving user experience and support diagnostics.

🤖 Generated with [Claude Code](https://claude.ai/code)