### PR TITLE
fix: add embed step to check script for CI pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
   "license": "MIT",
   "scripts": {
     "init": "bun run scripts/init-templates.ts",
+    "embed": "bun run scripts/embed-resources.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "format": "biome format --write .",
     "fix": "biome check --write .",
-    "check": "bun run typecheck && bun run lint",
+    "check": "bun run embed && bun run typecheck && bun run lint",
     "test": "bun test",
     "prebuild": "bun run scripts/embed-resources.ts",
     "build": "bun build src/cli/index.ts --compile --outfile dist/cc-track",


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions release workflow failure by ensuring embedded resources are generated before TypeScript compilation.

## Problem
The CI pipeline was failing with TypeScript errors:
- `Cannot find module '../lib/embedded-resources'`
- The `embedded-resources.ts` file is generated at build time but wasn't being created before type checking

## Solution
Added proper script ordering in package.json:
- Created `embed` script to run the embed-resources.ts generator
- Updated `check` script to run: `embed` → `typecheck` → `lint`
- This ensures the embedded resources file exists before TypeScript compilation

## Testing
- Verified locally that `bun run check` now works correctly
- The embed step generates the required file before TypeScript runs
- All checks pass locally

This should fix the release workflow and allow semantic-release to publish the npm package.

🤖 Generated with [Claude Code](https://claude.ai/code)