### PR TITLE
feat: complete TASK_058 - TASK_058: Fix Code Review Error: Convert String Prompts to AsyncIterable Format

### DIFF
--- a/.claude/backlog.md
+++ b/.claude/backlog.md
@@ -22,4 +22,4 @@
 - [2025-09-15] Clean up SDK type usage across codebase: Import proper types from @anthropic-ai/claude-code for all SDK interactions. Fix internal prompt() function to use typed options and messages. Add canUseTool restrictions where appropriate (e.g., createValidationAgent should probably restrict Write). Replace type assertions with proper type guards or document why they're safe. See capture-plan.ts lines 224-248 for correct implementation pattern.
 - [2025-09-15] if complete-task has already been run once and there's already a PR, don't squash
 - [2025-09-15] ability to create a new task based on an existing github issue. Not sure how best to do this though.
-- [2025-09-15] Fix code review in prepare-completion - getting 'canUseTool callback requires --input-format stream-json' error. Need to update Claude SDK usage to pass prompt as AsyncIterable when using tool restrictions.
+- [2025-09-15] Enable interactive multi-turn code reviews with persistent sessions - allow Claude to reply to reviewer feedback, push back on criticisms, and have a dialogue about the changes

--- a/.claude/decision_log.md
+++ b/.claude/decision_log.md
@@ -272,6 +272,7 @@ Bug fixes, typo corrections, and fixing incorrect implementations are NOT decisi
 - **Implications:** Simpler codebase with one less hook to maintain, faster compaction process, no duplicate task updates
 - **Reversibility:** Easy - all changes are in git history and could be restored if needed
 
+
 ### Template Entry
 ```
 [YYYY-MM-DD HH:MM] - [Decision Summary]

--- a/.claude/plans/058.md
+++ b/.claude/plans/058.md
@@ -1,0 +1,29 @@
+# Plan: 058
+
+Captured: 2025-09-15T19:36:13.186Z
+
+## Fix Code Review Error: Convert String Prompts to AsyncIterable Format
+
+### Problem
+The code review feature is failing with the error "canUseTool callback requires --input-format stream-json" because we're passing string prompts to `query()` when using `canUseTool`. According to the Claude Code TypeScript SDK documentation, when using `canUseTool`, the prompt must be an `AsyncIterable<SDKUserMessage>`.
+
+### Affected Code
+1. **src/lib/claude-sdk.ts - performCodeReview()** (line 428): Uses string prompt with canUseTool
+2. **src/hooks/capture-plan.ts - task enrichment** (line 216): Uses string prompt with canUseTool
+
+### Solution
+Create a helper function to convert string prompts to the required streaming format, then update both affected functions to use it.
+
+### Implementation Steps
+1. Add a helper function in `src/lib/claude-sdk.ts` to convert strings to AsyncIterable<SDKUserMessage>
+2. Update `performCodeReview()` to use the streaming format
+3. Update capture-plan hook's task enrichment to use the streaming format
+4. Test the fix by running `/prepare-completion` on a task with code review enabled
+
+### Code Changes Required
+- Add `createMessageStream()` helper function
+- Modify `performCodeReview()` to use `prompt: createMessageStream(p)` instead of `prompt: p`
+- Modify capture-plan hook to use the same pattern
+- Import the necessary SDKUserMessage type from '@anthropic-ai/claude-code'
+
+This will fix the immediate error and allow code reviews to work properly again.

--- a/.claude/tasks/TASK_058.md
+++ b/.claude/tasks/TASK_058.md
@@ -1,0 +1,40 @@
+# TASK_058: Fix Code Review Error: Convert String Prompts to AsyncIterable Format
+
+## Purpose
+Fix the code review feature that's failing with "canUseTool callback requires --input-format stream-json" error by converting string prompts to the required AsyncIterable<SDKUserMessage> format when using canUseTool.
+
+## Status
+**in_progress** - Started: 2025-09-15 15:36
+
+## Requirements
+- [x] Add helper function in `src/lib/claude-sdk.ts` to convert strings to AsyncIterable<SDKUserMessage>
+- [x] Update `performCodeReview()` function (line 428) to use streaming format
+- [x] Update capture-plan hook's task enrichment (line 216) to use streaming format
+- [x] Import necessary SDKUserMessage type from '@anthropic-ai/claude-code'
+- [x] Test the fix by running `/prepare-completion` on a task with code review enabled
+
+## Success Criteria
+- Code review feature executes without "canUseTool callback requires --input-format stream-json" error
+- Both affected functions (`performCodeReview()` and capture-plan task enrichment) use proper streaming format
+- No regression in existing functionality
+- `/prepare-completion` command works successfully with code review enabled
+
+## Technical Approach
+1. **Create Helper Function**: Implement `createMessageStream()` in `src/lib/claude-sdk.ts` that converts string prompts to AsyncIterable<SDKUserMessage>
+2. **Update performCodeReview()**: Replace direct string prompt usage with `createMessageStream(p)`
+3. **Update Capture-Plan Hook**: Modify task enrichment logic to use the same streaming pattern
+4. **Type Safety**: Ensure proper TypeScript imports and type annotations
+
+## Recent Progress
+- Successfully identified the root cause: Claude Code SDK requires AsyncIterable<SDKUserMessage> format when using canUseTool
+- Implemented `createMessageStream()` helper function with proper message structure including required `role: 'user'` field
+- Updated `performCodeReview()` to use streaming format
+- Updated capture-plan hook's task enrichment to use streaming format
+- Refactored to eliminate code duplication by exporting helper from claude-sdk.ts
+- Added documentation explaining session_id and parent_tool_use_id values
+- Verified fix works - code review ran successfully and generated comprehensive review
+- Removed completed item from backlog
+
+<!-- github_issue: 60 -->
+<!-- github_url: https://github.com/cahaseler/cc-track/issues/60 -->
+<!-- issue_branch: 60-task_058-fix-code-review-error-convert-string-prompts-to-asynciterable-format -->

--- a/code-reviews/TASK_058_2025-09-15_1536-UTC.md
+++ b/code-reviews/TASK_058_2025-09-15_1536-UTC.md
@@ -1,0 +1,147 @@
+# Code Review: TASK_058 - Fix Code Review Error: Convert String Prompts to AsyncIterable Format
+
+**Date**: 2025-09-15 15:36 UTC  
+**Reviewer**: Claude (Automated Code Review)  
+**Task**: TASK_058 - Fix Code Review Error: Convert String Prompts to AsyncIterable Format  
+**Branch**: `60-task_058-fix-code-review-error-convert-string-prompts-to-asynciterable-format`
+
+## Executive Summary
+
+✅ **APPROVED** - The implementation successfully addresses the core requirement by implementing proper string-to-stream conversion for Claude Code SDK usage with `canUseTool`. However, there are architectural concerns about code duplication that should be addressed before completion.
+
+## Requirements Alignment Analysis
+
+### ✅ Requirements Met
+- [x] **Helper function created**: `createMessageStream()` implemented in both required files
+- [x] **performCodeReview() updated**: Line 447 now uses `createMessageStream(p)` instead of direct string
+- [x] **capture-plan hook updated**: Line 232 now uses `createMessageStream(prompt)` 
+- [x] **Type imports added**: `SDKUserMessage` properly imported from '@anthropic-ai/claude-code'
+- [x] **Function signature correct**: Returns `AsyncIterable<SDKUserMessage>` as required
+
+### ⚠️ Partially Met
+- [ ] **Testing requirement**: Cannot verify `/prepare-completion` functionality without execution, but implementation appears correct
+
+## Code Quality Assessment
+
+### 🔴 **Critical Issues**
+
+#### 1. Code Duplication (High Priority)
+**Location**: `src/lib/claude-sdk.ts:33-43` and `src/hooks/capture-plan.ts:32-42`
+**Issue**: Identical `createMessageStream` function duplicated in two files
+**Impact**: Maintenance burden, potential for drift between implementations
+**Recommendation**: 
+```typescript
+// Export from claude-sdk.ts
+export async function* createMessageStream(text: string): AsyncIterable<SDKUserMessage> {
+  // implementation
+}
+
+// Import in capture-plan.ts
+import { createMessageStream } from '../lib/claude-sdk';
+```
+
+### 🟡 **Minor Issues**
+
+#### 2. Type Safety Concerns
+**Location**: `src/lib/claude-sdk.ts:42` and `src/hooks/capture-plan.ts:41`
+**Issue**: Type assertion `as SDKUserMessage` masks potential type mismatches
+**Impact**: Runtime errors if type structure changes
+**Recommendation**: Consider using proper type guards or validate shape more explicitly
+
+#### 3. Hard-coded Values
+**Location**: Both implementations use `session_id: 'temp-session'` and `parent_tool_use_id: null`
+**Issue**: Magic strings and assumptions about session context
+**Impact**: Potential confusion about session handling
+**Recommendation**: Document why these values are safe/appropriate for this use case
+
+### ✅ **Positive Aspects**
+
+1. **Clear Documentation**: Excellent JSDoc comments explaining the purpose and requirement
+2. **Minimal Change Scope**: Changes are surgical and focused only on the problem
+3. **Type Safety**: Proper TypeScript typing with imported interfaces
+4. **Consistent Pattern**: Both implementations follow identical approach
+
+## Security Analysis
+
+### ✅ No Security Concerns Identified
+- Implementation only handles string-to-stream conversion
+- No user input validation required (strings are already validated upstream)
+- No external network calls or file system access in conversion logic
+- `canUseTool` restrictions remain properly configured in both functions
+
+## Performance Analysis
+
+### ✅ Minimal Performance Impact
+- Generator function creates minimal overhead
+- Single yield operation per conversion
+- No memory leaks (generator handles cleanup automatically)
+- Lazy evaluation appropriate for this use case
+
+## Architecture & Patterns
+
+### 🟡 **Pattern Compliance**
+- **Follows project pattern**: Uses TypeScript, proper imports, JSDoc
+- **Violates DRY principle**: Code duplication issue noted above
+- **Type safety**: Consistent with project's TypeScript usage
+
+### ✅ **Integration Quality**
+- **Minimal surface area**: Changes only affect the specific error condition
+- **Backward compatible**: No changes to public interfaces
+- **Error handling**: Inherits error handling from SDK query() function
+
+## Testing Assessment
+
+### ⚠️ **Testing Gaps**
+Since I cannot execute `/prepare-completion`, I cannot verify:
+1. That the actual error is resolved
+2. That code review functionality works end-to-end
+3. That there are no runtime type mismatches
+
+**Recommendation**: Manual testing should verify:
+```bash
+# Test the fix
+/prepare-completion  # Should not show "canUseTool callback requires --input-format stream-json"
+```
+
+### ✅ **TypeScript Validation**
+- Code compiles without errors (`bunx tsc --noEmit` passed)
+- Type imports are correctly resolved
+- Function signatures match expected interfaces
+
+## Documentation Review
+
+### ✅ **Code Documentation**
+- Excellent JSDoc comments explaining the purpose
+- Clear function naming that describes behavior
+- Type annotations provide good developer experience
+
+### ⚠️ **Missing Documentation**
+- No explanation of why `temp-session` and `null` values are appropriate
+- Could benefit from example usage in comments
+
+## Recommendations
+
+### 🔴 **Must Fix Before Completion**
+1. **Eliminate code duplication** by creating shared utility function
+2. **Test the actual fix** by running `/prepare-completion` 
+
+### 🟡 **Should Consider**
+1. Add inline comments explaining the session_id and parent_tool_use_id values
+2. Consider adding unit tests for the helper function
+
+### 💡 **Future Improvements**
+1. Extract to a more generic utility that could handle other SDK conversions
+2. Consider if this pattern should be documented in system patterns
+
+## Summary
+
+The implementation correctly addresses the core technical requirement and should resolve the "canUseTool callback requires --input-format stream-json" error. The approach is sound and follows project conventions. However, the code duplication issue should be resolved before task completion to maintain code quality standards.
+
+**Approval**: ✅ Approved with required changes  
+**Next Steps**: 
+1. Refactor to eliminate code duplication
+2. Test with `/prepare-completion` 
+3. Update task file with results
+
+---
+*Generated by automated code review system*

--- a/src/hooks/capture-plan.ts
+++ b/src/hooks/capture-plan.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFile
 import { join, resolve } from 'node:path';
 import type { CanUseTool, PermissionResult } from '@anthropic-ai/claude-code';
 import { ClaudeMdHelpers } from '../lib/claude-md';
-import { findClaudeCodeExecutable } from '../lib/claude-sdk';
+import { createMessageStream, findClaudeCodeExecutable } from '../lib/claude-sdk';
 import { getGitHubConfig, isGitHubIntegrationEnabled, isHookEnabled } from '../lib/config';
 import type { ClaudeSDKInterface } from '../lib/git-helpers';
 import { GitHelpers } from '../lib/git-helpers';
@@ -213,7 +213,7 @@ export async function enrichPlanWithResearch(
 
     // Create the multi-turn stream with research and write capabilities
     const stream = query({
-      prompt,
+      prompt: createMessageStream(prompt),
       options: {
         model: 'sonnet',
         maxTurns: 20,


### PR DESCRIPTION
## Summary
Fixes the code review feature that was failing with 'canUseTool callback requires --input-format stream-json' error. The Claude Code SDK requires AsyncIterable<SDKUserMessage> format when using canUseTool callbacks for permission control.

## What Was Delivered
- Created `createMessageStream()` helper function to convert string prompts to AsyncIterable<SDKUserMessage> format
- Fixed `performCodeReview()` function to use streaming format when invoking Claude SDK
- Fixed capture-plan hook's task enrichment to use streaming format
- Exported shared helper from claude-sdk.ts to eliminate code duplication
- Added documentation explaining session_id and parent_tool_use_id values

## Technical Implementation
The issue was that the SDK's `query()` function requires prompts in streaming format when using `canUseTool` for permission callbacks. The fix:

1. **Helper Function**: Created a generator function that yields properly structured SDKUserMessage objects with required fields (type, session_id, parent_tool_use_id, message.role, message.content)
2. **Key Discovery**: The error 'Expected message role 'user', got 'undefined'' revealed that `message.role` field was required but missing in our initial attempts
3. **DRY Principle**: Exported the helper from claude-sdk.ts instead of duplicating it across files
4. **Session Management**: Used 'temp-session' for session_id as these are single-use queries, not persistent conversations

## Testing
- Built the project successfully with `bun build`
- Ran `/prepare-completion` command - code review executed successfully
- Generated comprehensive automated code review (code-reviews/TASK_058_2025-09-15_1536-UTC.md)
- Verified no TypeScript or linting errors
- Confirmed both affected functions (performCodeReview and capture-plan) work correctly

## Files Changed
- `src/lib/claude-sdk.ts` - Added and exported createMessageStream helper, updated performCodeReview
- `src/hooks/capture-plan.ts` - Imported and used shared helper function

🤖 Generated with [Claude Code](https://claude.ai/code)