### PR TITLE
fix: only stage task file instead of all files when creating task from issue

### DIFF
--- a/src/commands/create-task-from-issue.ts
+++ b/src/commands/create-task-from-issue.ts
@@ -134,9 +134,12 @@ _To be populated during implementation_
       // Commit task file to main branch
       console.log('💾 Committing task file...');
       const safeIssueNumber = String(issue.number).replace(/[^0-9]/g, '');
-      execSync(`git add . && git commit -m "feat: create TASK_${taskId} from GitHub issue #${safeIssueNumber}"`, {
-        cwd: projectRoot,
-      });
+      execSync(
+        `git add "${taskPath}" && git commit -m "feat: create TASK_${taskId} from GitHub issue #${safeIssueNumber}"`,
+        {
+          cwd: projectRoot,
+        },
+      );
 
       // Create issue branch if not disabled
       let branchName: string | null = null;


### PR DESCRIPTION
## Summary
Fixes GitHub Copilot P1 comment about overly broad git staging in create-task-from-issue command.

## What Changed
- Changed `git add .` to `git add "${taskPath}"` on line 137
- This ensures only the newly created task file is staged, not all files in the repository
- Prevents accidentally committing unrelated developer changes

## Why This Matters
The previous implementation using `git add .` could stage unintended files that developers had modified but not yet committed, leading to those changes being included in the automated task creation commit.

## Testing
- ✅ All 285 tests passing
- ✅ TypeScript validation passing
- ✅ Linting clean

🤖 Generated with [Claude Code](https://claude.ai/code)