### PR TITLE
feat: complete TASK_069 - TASK_069: Fix CodeRabbit/code-review Tests Filesystem Access

### DIFF
--- a/.claude/progress_log.md
+++ b/.claude/progress_log.md
@@ -26,6 +26,10 @@
 
 ## Log Entries
 
+[2025-09-17 11:45] - Completed: TASK_069 - Fix CodeRabbit/code-review Tests Filesystem Access
+  Details: Updated test files to use mock logger, eliminating filesystem dependencies in CI
+  Files: src/lib/code-review/coderabbit.test.ts, src/lib/code-review/index.test.ts
+
 [2025-09-15 15:35] - Completed: TASK_057 - Remove Post-Compact/SessionStart Hook
   Details: Successfully removed all post-compact hook functionality from the codebase
   Files: Deleted 2 files (post-compact.ts, post-compact.test.ts), modified 12 files across configs, source, tests, and docs

--- a/.claude/tasks/TASK_069.md
+++ b/.claude/tasks/TASK_069.md
@@ -7,11 +7,11 @@ Stop CodeRabbit/code-review tests from touching the real filesystem so CI (which
 **in_progress**
 
 ## Requirements
-- [ ] Update `src/lib/code-review/coderabbit.test.ts` to use mock logger
-- [ ] Update `src/lib/code-review/index.test.ts` to mock logger module
-- [ ] Verify tests pass locally with `bun test`
-- [ ] Verify tests pass in CI-like environment with `env HOME=/root bun test`
-- [ ] Ensure no changes to production code - only test files modified
+- [x] Update `src/lib/code-review/coderabbit.test.ts` to use mock logger
+- [x] Update `src/lib/code-review/index.test.ts` to mock logger module
+- [x] Verify tests pass locally with `bun test`
+- [x] Verify tests pass in CI-like environment with `env HOME=/root bun test`
+- [x] Ensure no changes to production code - only test files modified
 
 ## Success Criteria
 - All CodeRabbit/code-review tests pass without filesystem access
@@ -24,12 +24,22 @@ Stop CodeRabbit/code-review tests from touching the real filesystem so CI (which
 2. **index.test.ts**: Use `mock.module('../logger', ...)` to return mock logger before imports
 3. **Mock Implementation**: Leverage existing `createMockLogger` from `src/test-utils/command-mocks.ts`
 
-## Current Focus
-Starting with updating test files to use mock logger instead of real filesystem-dependent logger.
+## Recent Progress
 
-## Next Steps
-1. Import and integrate `createMockLogger` in coderabbit.test.ts
-2. Add module mocking for logger in index.test.ts  
-3. Run test verification in both normal and CI-like environments
+**2025-09-17 11:45** - Task completed successfully:
+- Updated `coderabbit.test.ts` to inject mock logger via existing deps parameter (5 test cases)
+- Updated `index.test.ts` to use `mock.module('../logger', ...)` for logger mocking (5 test cases)
+- All tests pass locally: 10/10 tests across 2 files
+- All tests pass in CI environment (HOME=/root): Verified no filesystem access errors
+- Code review approved: Clean implementation following established patterns
+- No production code changes required - only test files modified
 
 **Started:** 2025-09-17 08:45
+
+<!-- github_issue: 81 -->
+<!-- github_url: https://github.com/cahaseler/cc-track/issues/81 -->
+<!-- issue_branch: 81-task_069-fix-coderabbitcode-review-tests-filesystem-access -->
+
+## Current Focus
+
+Task completed on 2025-09-17

--- a/code-reviews/TASK_069_2025-09-17_1145-UTC.md
+++ b/code-reviews/TASK_069_2025-09-17_1145-UTC.md
@@ -1,0 +1,164 @@
+# Code Review: TASK_069 - Fix CodeRabbit/code-review Tests Filesystem Access
+
+**Task ID:** TASK_069  
+**Reviewed by:** Claude Code Review  
+**Date:** 2025-09-17T11:45:00Z  
+**Reviewer:** Claude (Sonnet 4)
+
+## Summary
+
+✅ **APPROVED** - Changes successfully address all task requirements with clean implementation.
+
+The changes properly isolate code-review tests from filesystem access by integrating the existing `createMockLogger()` function into both test files. This prevents CI failures where `~/.local/share/cc-track/logs` is not writable.
+
+## Requirements Analysis
+
+### ✅ All Requirements Met
+
+- [x] **Update `src/lib/code-review/coderabbit.test.ts` to use mock logger**: Successfully integrated via dependency injection
+- [x] **Update `src/lib/code-review/index.test.ts` to mock logger module**: Proper module mocking implemented
+- [x] **Verify tests pass locally**: Tests pass (10/10 across 2 files)
+- [x] **CI-like environment compatibility**: Implementation prevents filesystem access
+- [x] **No production code changes**: Only test files modified
+- [x] **Mock logger implements full interface**: Uses existing `createMockLogger` with all required methods
+
+## Code Quality Analysis
+
+### Excellent Implementation ⭐
+
+**Strengths:**
+1. **Leverages Existing Infrastructure**: Uses established `createMockLogger()` from `src/test-utils/command-mocks.ts` rather than duplicating implementation
+2. **Consistent Patterns**: Follows the project's dependency injection pattern used throughout coderabbit.test.ts
+3. **Comprehensive Coverage**: All test cases in both files now use mocked logger
+4. **Clean Integration**: Module mocking in index.test.ts is properly scoped per test
+
+### Code Structure
+
+**coderabbit.test.ts (Lines 26, 86, 133, 171, 207):**
+```typescript
+logger: createMockLogger(),
+```
+- Clean dependency injection pattern
+- Consistent with existing test structure
+- No changes to test logic, only infrastructure
+
+**index.test.ts (Lines 15-17, 46-48, 82-84, 113-115, 139-141):**
+```typescript
+mock.module('../logger', () => ({
+  createLogger: () => createMockLogger(),
+}));
+```
+- Proper module mocking before imports
+- Isolated per test case
+- Preserves original logger interface
+
+## Architecture & Patterns Compliance
+
+### ✅ Excellent Pattern Adherence
+
+1. **Dependency Injection**: Perfectly follows established pattern in coderabbit.test.ts
+2. **Module Mocking**: Uses Bun's mock.module API correctly in index.test.ts  
+3. **Test Isolation**: Each test properly mocks its dependencies
+4. **Interface Compliance**: Mock logger implements all required methods (debug, info, warn, error, exception)
+
+## Security Analysis
+
+### ✅ No Security Concerns
+
+- Changes are test-only modifications
+- No exposure of sensitive data
+- Prevents unintended filesystem access in CI environments
+- Uses existing, validated mock infrastructure
+
+## Performance Impact
+
+### ✅ Performance Improvement
+
+- **Eliminates I/O**: Tests no longer perform filesystem operations
+- **Faster Execution**: Mock functions have zero latency vs file operations
+- **CI Reliability**: Removes dependency on writable log directories
+
+## Error Handling
+
+### ✅ Robust Error Handling
+
+- Mock logger gracefully handles all logging calls
+- Tests maintain original error scenarios and assertions
+- No new error paths introduced
+- Preserves existing timeout and CLI error testing
+
+## Testing Quality
+
+### ✅ Comprehensive Test Coverage Maintained
+
+**Test Coverage Analysis:**
+- All 5 test cases in coderabbit.test.ts now use mock logger
+- All 5 test cases in index.test.ts properly mock the logger module
+- Original test assertions and scenarios preserved
+- Mock implementation covers full logger interface
+
+**Missing Test Cases:** None - existing coverage is appropriate for the change scope.
+
+## Technical Implementation Details
+
+### Mock Logger Integration
+
+**Existing Mock Implementation** (src/test-utils/command-mocks.ts:132-140):
+```typescript
+export function createMockLogger(): ReturnType<typeof createLogger> {
+  return {
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    exception: mock(() => {}),
+  } as unknown as ReturnType<typeof createLogger>;
+}
+```
+
+This provides a complete logger interface that satisfies TypeScript typing and runtime requirements.
+
+### Module Mocking Strategy
+
+The index.test.ts uses module-level mocking which intercepts the `createLogger` import, ensuring the main index.ts file receives the mock logger when it calls:
+```typescript
+const logger = createLogger('code-review');
+```
+
+This approach is superior to dependency injection for this file since the main function doesn't accept logger dependencies.
+
+## Documentation
+
+### ✅ Adequate Documentation
+
+- Code is self-documenting through clear patterns
+- Task file properly tracks progress
+- Changes align with documented technical approach
+- No additional documentation needed for this scope
+
+## Recommendations
+
+### None Required ✅
+
+The implementation is clean, follows established patterns, and completely addresses the requirements. No improvements needed.
+
+## Conclusion
+
+**APPROVED** - This is a textbook example of a focused, well-executed bug fix:
+
+1. **Problem**: CI failing due to logger filesystem access
+2. **Solution**: Mock logger to eliminate filesystem dependency  
+3. **Implementation**: Leverage existing mock infrastructure with minimal changes
+4. **Result**: Tests pass in both normal and CI environments
+
+The changes are minimal, safe, and effective. The task is complete and ready for merge.
+
+---
+
+**Files Modified:**
+- `src/lib/code-review/coderabbit.test.ts`: Added mock logger to dependency injection (5 locations)
+- `src/lib/code-review/index.test.ts`: Added module mocking for logger (5 test cases)
+- `.claude/tasks/TASK_069.md`: Updated with GitHub issue metadata
+- `CLAUDE.md`: Updated active task reference
+
+**Test Results:** ✅ 10/10 tests passing across 2 files

--- a/src/lib/code-review/coderabbit.test.ts
+++ b/src/lib/code-review/coderabbit.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { createMockLogger } from '../../test-utils/command-mocks';
 import { performCodeRabbitReview } from './coderabbit';
 import type { CodeReviewOptions } from './types';
 
@@ -22,6 +23,7 @@ describe('performCodeRabbitReview', () => {
 
     const result = await performCodeRabbitReview(options, {
       execSync: mockExec,
+      logger: createMockLogger(),
     });
 
     expect(result.success).toBe(false);
@@ -81,6 +83,7 @@ Review completed ✔`;
     const result = await performCodeRabbitReview(options, {
       execSync: mockExec,
       fileOps: mockFileOps as any,
+      logger: createMockLogger(),
     });
 
     expect(result.success).toBe(true);
@@ -127,6 +130,7 @@ Review completed ✔`;
     const result = await performCodeRabbitReview(options, {
       execSync: mockExec,
       fileOps: mockFileOps as any,
+      logger: createMockLogger(),
     });
 
     expect(result.success).toBe(true);
@@ -164,6 +168,7 @@ Review completed ✔`;
     const result = await performCodeRabbitReview(options, {
       execSync: mockExec,
       fileOps: mockFileOps as any,
+      logger: createMockLogger(),
     });
 
     expect(result.success).toBe(false);
@@ -199,6 +204,7 @@ Review completed ✔`;
     const result = await performCodeRabbitReview(options, {
       execSync: mockExec,
       fileOps: mockFileOps as any,
+      logger: createMockLogger(),
     });
 
     expect(result.success).toBe(true);

--- a/src/lib/code-review/index.test.ts
+++ b/src/lib/code-review/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { createMockLogger } from '../../test-utils/command-mocks';
 import type { CodeReviewOptions } from './types';
 
 describe('performCodeReview', () => {
@@ -11,6 +12,10 @@ describe('performCodeReview', () => {
   });
 
   test('returns error when code review is disabled', async () => {
+    mock.module('../logger', () => ({
+      createLogger: () => createMockLogger(),
+    }));
+
     mock.module('../config', () => ({
       isCodeReviewEnabled: () => false,
       getCodeReviewTool: () => 'claude',
@@ -36,6 +41,10 @@ describe('performCodeReview', () => {
     const mockPerformClaudeReview = mock(async () => ({
       success: true,
       review: 'Claude review content',
+    }));
+
+    mock.module('../logger', () => ({
+      createLogger: () => createMockLogger(),
     }));
 
     mock.module('../config', () => ({
@@ -70,6 +79,10 @@ describe('performCodeReview', () => {
       review: 'CodeRabbit review content',
     }));
 
+    mock.module('../logger', () => ({
+      createLogger: () => createMockLogger(),
+    }));
+
     mock.module('../config', () => ({
       isCodeReviewEnabled: () => true,
       getCodeReviewTool: () => 'coderabbit',
@@ -97,6 +110,10 @@ describe('performCodeReview', () => {
   });
 
   test('handles unknown tool gracefully', async () => {
+    mock.module('../logger', () => ({
+      createLogger: () => createMockLogger(),
+    }));
+
     mock.module('../config', () => ({
       isCodeReviewEnabled: () => true,
       getCodeReviewTool: () => 'unknown-tool' as any,
@@ -119,6 +136,10 @@ describe('performCodeReview', () => {
   });
 
   test('handles tool errors gracefully', async () => {
+    mock.module('../logger', () => ({
+      createLogger: () => createMockLogger(),
+    }));
+
     mock.module('../config', () => ({
       isCodeReviewEnabled: () => true,
       getCodeReviewTool: () => 'claude',


### PR DESCRIPTION
## Summary
Completes TASK_069: Fix CodeRabbit/code-review Tests Filesystem Access

This PR fixes CI test failures by preventing code-review tests from attempting to access the filesystem for logging, which was failing in CI environments where ~/.local/share/cc-track/logs is not writable.

## What Was Delivered
- Updated `src/lib/code-review/coderabbit.test.ts` to inject mock logger via dependency injection (5 test cases)
- Updated `src/lib/code-review/index.test.ts` to mock the logger module (5 test cases)  
- Zero production code changes - only test files modified
- All 10 tests now pass in both normal and CI-like environments

## Technical Implementation
### Approach
Two different mocking strategies were used based on the code structure:

1. **Dependency Injection** (coderabbit.test.ts):
   - Leveraged existing `deps` parameter to pass `createMockLogger()` 
   - Pattern: `{ execSync: mockExec, fileOps: mockFileOps, logger: createMockLogger() }`

2. **Module Mocking** (index.test.ts):
   - Used `mock.module('../logger', ...)` to intercept logger creation
   - Prevents the main module from creating real filesystem-dependent logger

### Mock Implementation
- Reused existing `createMockLogger()` from `src/test-utils/command-mocks.ts`
- Mock implements full logger interface: debug, info, warn, error, exception
- No filesystem operations performed - all logging is no-op

## Testing
### Local Testing
- `bun test src/lib/code-review/coderabbit.test.ts`: ✅ 5/5 tests pass
- `bun test src/lib/code-review/index.test.ts`: ✅ 5/5 tests pass

### CI Environment Testing  
- `env HOME=/root bun test src/lib/code-review`: ✅ All 10 tests pass
- No filesystem permission errors
- Verified logger no longer attempts to create/write to log directories

### Code Review Results
- Automated code review: **APPROVED**
- Clean implementation following established patterns
- No issues or concerns identified

🤖 Generated with [Claude Code](https://claude.ai/code)