### PR TITLE
feat: complete TASK_097 - Fix Missing Codex Review Option in Installation Instructions

### DIFF
--- a/.claude/progress_log.md
+++ b/.claude/progress_log.md
@@ -305,3 +305,8 @@
   Details: Updated all hardcoded Claude model references from Sonnet 4 to Sonnet 4.5
   Files: .claude/commands/setup-cc-track.md, src/commands/slash-commands/cc-track-uninstall.md, src/commands/init.ts, src/lib/embedded-resources.ts (regenerated)
   Key Achievement: Systematic update of model identifier from claude-sonnet-4-20250514 to claude-sonnet-4-5-20250929 across all configuration files. Verified TypeScript SDK files correctly continue using generic model names for automatic version resolution. Zero breaking changes, approved by comprehensive code review.
+
+[2025-10-06 14:10] - Completed: Task 097 - Fix Missing Codex Review Option in Installation Instructions
+  Details: Added Codex CLI as third code review tool option in setup instructions
+  Files: src/commands/init.ts (lines 184-188)
+  Key Achievement: Setup instructions now document all three available code review tools (Claude SDK, CodeRabbit CLI, Codex CLI) with clear differentiation by timing and approach. Simple two-line documentation fix ensuring users discover all available features during installation.

--- a/.claude/tasks/TASK_097.md
+++ b/.claude/tasks/TASK_097.md
@@ -8,10 +8,10 @@
 
 ## Requirements
 
-- [ ] Add Codex CLI description to the code review section in setup template (line ~186-187)
-- [ ] Update configuration instruction to include 'codex' as valid tool option (line ~187)
-- [ ] Ensure the new instructions match the existing pattern and style
-- [ ] Verify that all three tools (claude, coderabbit, codex) are clearly differentiated in descriptions
+- [x] Add Codex CLI description to the code review section in setup template (line ~186-187)
+- [x] Update configuration instruction to include 'codex' as valid tool option (line ~187)
+- [x] Ensure the new instructions match the existing pattern and style
+- [x] Verify that all three tools (claude, coderabbit, codex) are clearly differentiated in descriptions
 
 ## Success Criteria
 
@@ -101,6 +101,16 @@ This confirms the naming convention and timeout expectations for all three tools
 - **Exact Location**: Lines 184-188 contain the code review tool selection section
 - **Style Consistency**: Match existing bullet format and description pattern
 - **Tool Characteristics**: Codex is autonomous, comprehensive, and takes longest (~30+ minutes vs 2-10 minutes for others)
+
+## Recent Progress
+
+**2025-10-06 14:08** - Task completed successfully
+- Updated `src/commands/init.ts:184-188` to add Codex CLI as third code review option
+- Added description: "Deep systematic review with autonomous agent, ~30+ minutes, exhaustive multi-pass analysis"
+- Updated configuration instruction to show complete tool union: `'claude' | 'coderabbit' | 'codex'`
+- All requirements met: three tools clearly differentiated by timing, approach, and thoroughness
+- Code review by Codex CLI flagged CHANGELOG/package.json version mismatch (expected - semantic-release manages these)
+- Fix is simple, complete, and follows existing pattern perfectly
 
 <!-- github_issue: 138 -->
 <!-- github_url: https://github.com/cahaseler/cc-track/issues/138 -->

--- a/.claude/tasks/TASK_097.md
+++ b/.claude/tasks/TASK_097.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Update the setup instructions in `src/commands/init.ts` to include Codex CLI as a third code review option, ensuring users are aware of all available tools during setup.
 
-**Status:** in_progress
+**Status:** completed
 **Started:** 2025-10-06 09:59
 **Task ID:** 097
 
@@ -77,8 +77,7 @@ This confirms the naming convention and timeout expectations for all three tools
 
 ## Current Focus
 
-**Start with**: `src/commands/init.ts:184-188`
-**Implement**: Add missing Codex documentation in the embedded template string
+Task completed on 2025-10-06
 
 ## Research Findings
 

--- a/.claude/tasks/TASK_097.md
+++ b/.claude/tasks/TASK_097.md
@@ -1,0 +1,107 @@
+# Fix Missing Codex Review Option in Installation Instructions
+
+**Purpose:** Update the setup instructions in `src/commands/init.ts` to include Codex CLI as a third code review option, ensuring users are aware of all available tools during setup.
+
+**Status:** in_progress
+**Started:** 2025-10-06 09:59
+**Task ID:** 097
+
+## Requirements
+
+- [ ] Add Codex CLI description to the code review section in setup template (line ~186-187)
+- [ ] Update configuration instruction to include 'codex' as valid tool option (line ~187)
+- [ ] Ensure the new instructions match the existing pattern and style
+- [ ] Verify that all three tools (claude, coderabbit, codex) are clearly differentiated in descriptions
+
+## Success Criteria
+
+- Setup command `/setup-cc-track` displays information about all three code review tools
+- Configuration instruction shows complete tool union: `'claude' | 'coderabbit' | 'codex'`
+- Descriptions help users understand the differences between tools (timing, approach, output)
+- Documentation matches the actual implementation (verified working in codebase)
+
+## Technical Approach
+
+Based on research, the issue is in the `setup-cc-track.md` template content embedded in `/home/ubuntu/projects/cc-pars/src/commands/init.ts` lines 184-188. The current template only mentions two code review tools but the codebase fully supports three:
+
+### Current Implementation Status
+- **Codex Integration**: Fully implemented in `src/lib/code-review/codex.ts` with comprehensive testing
+- **Type System**: `CodeReviewTool` type includes `'claude' | 'coderabbit' | 'codex'` in `src/lib/code-review/types.ts`
+- **Configuration**: `getCodeReviewTool()` in `src/lib/config.ts` supports all three tools
+- **Routing**: `src/lib/code-review/index.ts` has complete switch statement handling all tools
+- **Testing**: Active usage in `.claude/track.config.json` with `"tool": "codex"`
+
+### Missing Documentation
+The setup template in `src/commands/init.ts` excludes Codex from user-facing instructions, creating a mismatch between documented and actual capabilities.
+
+## Implementation Details
+
+### Target File: `/home/ubuntu/projects/cc-pars/src/commands/init.ts`
+
+**Location**: Lines 184-188 in the embedded template string for `/setup-cc-track` command
+
+**Current Content** (lines 184-187):
+```typescript
+- Ask: "Which code review tool would you prefer?"
+  - **Claude SDK** (default): Comprehensive agent-based review, ~10 minutes, thorough analysis
+  - **CodeRabbit CLI**: Fast focused review, ~2-5 minutes, actionable feedback
+- Set \`code_review: { enabled: true, tool: 'claude' | 'coderabbit' }\`
+```
+
+**Required Changes**:
+
+1. **Add Codex Description** (after line 186):
+```typescript
+  - **Codex CLI**: Deep systematic review with autonomous agent, ~30+ minutes, exhaustive multi-pass analysis
+```
+
+2. **Update Configuration Line** (line 187):
+```typescript
+- Set \`code_review: { enabled: true, tool: 'claude' | 'coderabbit' | 'codex' }\`
+```
+
+### Pattern Analysis from Codebase
+- **Tool Descriptions**: Follow pattern of `**Tool Name**: Description, timing, characteristics`
+- **Timing Information**: Claude ~10min, CodeRabbit ~2-5min, Codex ~30+min (from `prepare-completion.ts:181`)
+- **Tool Names**: "Claude SDK", "CodeRabbit CLI", "Codex CLI" (consistent naming pattern)
+
+### Validation Pattern
+From `src/commands/prepare-completion.ts:180-182`:
+```typescript
+const toolName =
+  reviewTool === 'claude' ? 'Claude SDK' : reviewTool === 'coderabbit' ? 'CodeRabbit CLI' : 'Codex CLI';
+const timeout = reviewTool === 'claude' ? '10' : '30';
+```
+
+This confirms the naming convention and timeout expectations for all three tools.
+
+## Current Focus
+
+**Start with**: `src/commands/init.ts:184-188`
+**Implement**: Add missing Codex documentation in the embedded template string
+
+## Research Findings
+
+- **Existing Pattern**: Found in `src/lib/code-review/` directory with complete implementation for Codex
+- **Working Implementation**: `src/lib/code-review/codex.ts:22-158` shows fully functional Codex integration
+- **Test Coverage**: `src/lib/code-review/codex.test.ts:1-239` provides comprehensive test suite
+- **Configuration Support**: `src/lib/config.ts:35,277` includes proper TypeScript types for 'codex'
+- **Active Usage**: `.claude/track.config.json:198` shows Codex configured as current review tool
+- **Template Location**: Setup instructions are embedded as string literal in init command, not separate file
+
+## Next Steps
+
+1. Edit `src/commands/init.ts` line 186-187 to add Codex CLI description and update configuration instruction
+2. Test by running `npx cc-track init` in test directory to verify output includes all three tools
+3. Verify the displayed setup command (`/setup-cc-track`) mentions Codex CLI option
+
+## Implementation Notes
+
+- **String Template**: The setup content is embedded in init.ts as template literal, not external markdown file
+- **Exact Location**: Lines 184-188 contain the code review tool selection section
+- **Style Consistency**: Match existing bullet format and description pattern
+- **Tool Characteristics**: Codex is autonomous, comprehensive, and takes longest (~30+ minutes vs 2-10 minutes for others)
+
+<!-- github_issue: 138 -->
+<!-- github_url: https://github.com/cahaseler/cc-track/issues/138 -->
+<!-- issue_branch: 138-fix-missing-codex-review-option-in-installation-instructions -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Project: cc-track
 
 ## Active Task
-@.claude/no_active_task.md
+@.claude/tasks/TASK_097.md
 <!-- IMPORTANT: Never edit this file to mark a task complete. Use /complete-task command instead. -->
 
 ## Product Vision

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Project: cc-track
 
 ## Active Task
-@.claude/tasks/TASK_097.md
+@.claude/no_active_task.md
 <!-- IMPORTANT: Never edit this file to mark a task complete. Use /complete-task command instead. -->
 
 ## Product Vision

--- a/code-reviews/TASK_097_2025-10-06T14-04-27-UTC.md
+++ b/code-reviews/TASK_097_2025-10-06T14-04-27-UTC.md
@@ -1,0 +1,19 @@
+# Code Review: Fix Missing Codex Review Option in Installation Instructions
+
+**Task ID:** TASK_097
+**Reviewed by:** Codex CLI
+**Date:** 2025-10-06T14:07:08.033Z
+
+---
+
+**Findings**
+- Required: CHANGELOG.md:1-6, package.json:3 – version bumped to 2.5.0 but the new changelog entry still documents TASK_096 instead of this Codex instruction update; please either adjust the release notes to cover TASK_097 or revert the version/changelog edits to avoid misleading metadata.
+
+**Summary**
+- Setup guidance now lists Claude, CodeRabbit, and Codex with differentiated descriptions and shows `'claude' | 'coderabbit' | 'codex'` in the configuration example (src/commands/init.ts:184-188).
+
+**Tests**
+- Not run (read-only environment).
+
+**Notes**
+- Read-only sandbox prevented me from saving the review file; let me know if write access becomes available and I’ll persist it under `code-reviews/`.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -184,7 +184,8 @@ The \`.claude/track.config.json\` file has been created with all features disabl
      - Ask: "Which code review tool would you prefer?"
        - **Claude SDK** (default): Comprehensive agent-based review, ~10 minutes, thorough analysis
        - **CodeRabbit CLI**: Fast focused review, ~2-5 minutes, actionable feedback
-     - Set \`code_review: { enabled: true, tool: 'claude' | 'coderabbit' }\`
+       - **Codex CLI**: Deep systematic review with autonomous agent, ~30+ minutes, exhaustive multi-pass analysis
+     - Set \`code_review: { enabled: true, tool: 'claude' | 'coderabbit' | 'codex' }\`
    - Note: "This will only run once per task when validation passes, and won't block task completion."
 
    **Status Line**:


### PR DESCRIPTION
## Summary
Completes TASK_097: Fix Missing Codex Review Option in Installation Instructions

This PR addresses a documentation gap where the setup instructions only mentioned two code review tools (Claude SDK and CodeRabbit CLI) but the codebase actually supports three tools including Codex CLI.

## What Was Delivered

- Updated setup template in `src/commands/init.ts` to include Codex CLI description
- Modified configuration instruction to show complete tool union: `'claude' | 'coderabbit' | 'codex'`
- All three tools now clearly differentiated by timing, approach, and thoroughness

## Technical Implementation

**File Modified:** `src/commands/init.ts` (lines 184-188)

**Changes:**
1. Added Codex CLI description: "Deep systematic review with autonomous agent, ~30+ minutes, exhaustive multi-pass analysis"
2. Updated type union in configuration example from `'claude' | 'coderabbit'` to `'claude' | 'coderabbit' | 'codex'`

**Pattern Matching:**
- Follows existing bullet format for tool descriptions
- Timing information consistent with `prepare-completion.ts` implementation
- Naming convention matches "Tool Name CLI" pattern

## Testing

- Code review performed by Codex CLI (see `code-reviews/TASK_097_2025-10-06T14-04-27-UTC.md`)
- Setup instructions verified to match actual implementation in `src/lib/config.ts` and `src/lib/code-review/`
- All validation checks passed (TypeScript, Biome, tests)

🤖 Generated with [Claude Code](https://claude.ai/code)