### PR TITLE
fix: change repository field from object to string per Claude Code schema

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,10 +6,7 @@
     "name": "Craig",
     "url": "https://github.com/cahaseler/cc-track"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/cahaseler/cc-track"
-  },
+  "repository": "https://github.com/cahaseler/cc-track",
   "keywords": [
     "claude-code",
     "task-tracking",


### PR DESCRIPTION
Fixes plugin installation error where Claude Code expects repository field to be a string, not an object with type/url fields.

Error: `repository: Expected string, received object`

The plugin manifest schema requires repository to be a simple string URL, not the npm package.json format.