### PR TITLE
fix: add backticks to backlog command and warning to complete-task

### DIFF
--- a/.cc-track/backlog.md
+++ b/.cc-track/backlog.md
@@ -20,5 +20,3 @@
 - [2025-12-06] Improve task generate mode to explicitly plan which sets of tasks can be assigned to subagents, which subagents to use, workflow for validating subagent work, etc. Take guidance from anthropic's feature dev skill and obrajesse's superpowers skills.
 - [2025-12-06] Update guidelines-reviewer agent definition to read spec.md/plan.md for task context before flagging 'unauthorized changes' - currently reviews in isolation without awareness of approved scope
 - [2025-12-06] Update prepare completion command to properly emulate the anthropic reviewer agent with the full process including seperate scoring agent, rather than the half-finished version that was implemented and allows the agent to take shortcuts.
-- [2025-12-06] Update complete-task command to warn Claude that it has swapped the current branch back to main, otherwise he might see that files have been "reverted" and misunderstand
-- [2025-12-06] Fix /cc-track:add-to-backlog command - the !echo command silently failed to append to the file

--- a/.cc-track/specs/106-fix-backlog-command-and-complete-task-warning/.metadata.json
+++ b/.cc-track/specs/106-fix-backlog-command-and-complete-task-warning/.metadata.json
@@ -1,0 +1,7 @@
+{
+  "task_id": "106",
+  "feature_name": "fix-backlog-command-and-complete-task-warning",
+  "branch": "106-fix-backlog-command-and-complete-task-warning",
+  "status": "in_progress",
+  "started": "2025-12-06T12:00:00Z"
+}

--- a/.cc-track/specs/106-fix-backlog-command-and-complete-task-warning/spec.md
+++ b/.cc-track/specs/106-fix-backlog-command-and-complete-task-warning/spec.md
@@ -1,0 +1,38 @@
+# Feature Specification: Fix Backlog Command and Complete-Task Warning
+
+**Feature ID**: `106`
+**Branch**: `106-fix-backlog-command-and-complete-task-warning`
+**Created**: 2025-12-06
+**Status**: Specified
+
+## Quick Summary
+
+Two minor fixes:
+1. Fix `/cc-track:add-to-backlog` command - bash not executing due to missing backticks
+2. Add warning to `/cc-track:complete-task` command about branch switch to main
+
+---
+
+## Requirements
+
+### Fix 1: Backlog Command (FR-1xx)
+- **FR-101**: The `!echo` line in add-to-backlog.md MUST use backtick syntax: `` !`command` ``
+- **FR-102**: After fix, running `/cc-track:add-to-backlog "text"` MUST append timestamped entry to backlog.md
+
+### Fix 2: Complete-Task Warning (FR-2xx)
+- **FR-201**: The complete-task.md command MUST include a note warning Claude that the script switches back to main branch
+- **FR-202**: Warning should explain that files appearing "reverted" is expected behavior, not an error
+
+---
+
+## Root Cause Analysis
+
+**Backlog command bug**: The `!` prefix requires backticks around the command for bash execution. Current syntax `!echo "..."` is treated as literal text. Correct syntax is `` !`echo "..."` ``.
+
+Evidence: `commands/specify.md` uses `` !`ls ...` `` and executes correctly.
+
+---
+
+## Success Criteria
+- [ ] `/cc-track:add-to-backlog "test"` successfully appends to backlog.md
+- [ ] complete-task.md contains warning about branch switch behavior

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Project: cc-track
 
 ## Active Task
-@.cc-track/specs/105-cc-track-workflow-cleanup/spec.md
+@.cc-track/specs/106-fix-backlog-command-and-complete-task-warning/spec.md
 
 ## Product Vision
 @.cc-track/product_context.md

--- a/commands/add-to-backlog.md
+++ b/commands/add-to-backlog.md
@@ -5,7 +5,7 @@ usage: /add-to-backlog "Your idea or bug description"
 allowed-tools: Bash(echo:*)
 ---
 
-!echo "- [$(date +%Y-%m-%d)] $ARGUMENTS" >> .cc-track/backlog.md
+!`echo "- [$(date +%Y-%m-%d)] $ARGUMENTS" >> .cc-track/backlog.md`
 
 ✅ Added to backlog
 

--- a/commands/complete-task.md
+++ b/commands/complete-task.md
@@ -56,6 +56,8 @@ The script returns JSON-like output with messages and data. Parse and present th
 - Report PR status: URL if created, or existing PR if updated
 - Confirm branch switch to main
 
+**Important:** The script switches you back to the main branch. Files may appear to have "reverted" to their pre-task state - this is expected. The task changes are preserved on the feature branch and in the PR.
+
 ## Step 4: Enhance PR Description (if PR was created)
 
 If a new PR was created, enhance its description with details from the spec files:


### PR DESCRIPTION
## Summary
- Fix `/cc-track:add-to-backlog` command by wrapping echo in backticks for bash execution
- Add warning in `complete-task.md` about branch switch back to main

## Root Cause
The `!` prefix in slash commands requires backticks around the command: `` !`command` ``. The backlog command was missing backticks, causing the echo to be printed as literal text instead of executed.

## Changes
- `commands/add-to-backlog.md`: `!echo "..."` → `` !`echo "..."` ``
- `commands/complete-task.md`: Added note explaining that files appearing "reverted" after completion is expected (branch switched to main)

## Test Plan
- [ ] Run `/cc-track:add-to-backlog "test item"` and verify item appears in backlog.md
- [ ] Run `/cc-track:complete-task` and observe the warning about branch switch

🤖 Generated with [Claude Code](https://claude.ai/code)