### PR TITLE
fix: use script-based approach for add-to-backlog command

### DIFF
--- a/.cc-track/specs/106-fix-backlog-command-and-complete-task-warning/spec.md
+++ b/.cc-track/specs/106-fix-backlog-command-and-complete-task-warning/spec.md
@@ -27,9 +27,11 @@ Two minor fixes:
 
 ## Root Cause Analysis
 
-**Backlog command bug**: The `!` prefix requires backticks around the command for bash execution. Current syntax `!echo "..."` is treated as literal text. Correct syntax is `` !`echo "..."` ``.
+**Backlog command bug (initial)**: The `!` prefix requires backticks around the command for bash execution. Original syntax `!echo "..."` was treated as literal text. Correct syntax is `` !`echo "..."` ``.
 
-Evidence: `commands/specify.md` uses `` !`ls ...` `` and executes correctly.
+**Backlog command bug (second issue)**: After adding backticks, Claude Code's permission system blocks `$()` command substitution in bash commands, regardless of allowed-tools. The date expansion `$(date +%Y-%m-%d)` triggers this security check with error: "Command contains $() command substitution".
+
+**Solution**: Use the existing `backlog.ts` script which uses `deps.time.todayISO()` for reliable system date. This follows the skill + script pattern used by other commands and avoids both the bash execution and permission issues.
 
 ---
 

--- a/commands/add-to-backlog.md
+++ b/commands/add-to-backlog.md
@@ -2,11 +2,15 @@
 shortname: add-to-backlog
 description: Quickly add an item to the backlog without disrupting current work
 usage: /add-to-backlog "Your idea or bug description"
-allowed-tools: Bash(echo:*)
+allowed-tools: Bash(bun:*), Skill
 ---
 
-!`echo "- [$(date +%Y-%m-%d)] $ARGUMENTS" >> .cc-track/backlog.md`
+# Add to Backlog
 
-✅ Added to backlog
+Invoke the `cc-track:cc-track-tools` skill to get the script path, then run:
+
+```bash
+bun {base_directory}/scripts/backlog.ts "$ARGUMENTS"
+```
 
 Do not change your current focus or priorities. Continue with your work if there was a clear task you are working on.


### PR DESCRIPTION
## Summary
Fix the `/cc-track:add-to-backlog` command by switching from bash to the existing TypeScript script.

## Root Cause
The bash approach failed due to two issues:
1. **Missing backticks**: `!echo` needed to be `` !`echo` `` for bash execution
2. **Permission block**: Even with backticks, Claude Code blocks `$()` command substitution with error "Command contains $() command substitution"

## Solution
Use the existing `backlog.ts` script which:
- Handles dates reliably via `deps.time.todayISO()` (system date, not Claude's imagination)
- Follows the skill + script pattern used by other commands
- Avoids bash permission issues entirely

## Test Plan
- [ ] Run `/cc-track:add-to-backlog "test item"` and verify item appears in backlog.md with correct date

🤖 Generated with [Claude Code](https://claude.ai/code)