### PR TITLE
feat: make autoflow configurable and opt-in

### DIFF
--- a/commands/config-track.md
+++ b/commands/config-track.md
@@ -40,8 +40,13 @@ The config file has three main sections: `hooks`, `features`, and `logging`.
     }
     ```
 
+### Features Section
+
+**Autonomous Operation:**
+
 - `autoflow` - Autonomous operation mode for unattended task completion
-  - Per-message opt-in: include "autoflow" in your message to activate
+  - **Disabled by default** - must be explicitly enabled
+  - Per-message opt-in: include "autoflow" in your message to activate for that task
   - Permission requests denied with "find safe alternative" guidance
   - Throttle detection prevents runaway sessions
   - Sub-options:
@@ -55,8 +60,6 @@ The config file has three main sections: `hooks`, `features`, and `logging`.
       "window_duration_minutes": 5
     }
     ```
-
-### Features Section
 
 **Git & GitHub Integration:**
 

--- a/hooks/permission-request.ts
+++ b/hooks/permission-request.ts
@@ -1,10 +1,13 @@
 #!/usr/bin/env bun
 /**
  * PermissionRequest Hook - Denies permissions in autoflow mode with helpful message
+ *
+ * IMPORTANT: Autoflow must be enabled in track.config.json to function.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { isCcTrackConfigured, isHookEnabled } from '../skills/cc-track-tools/lib/config';
 
 export interface HookInput {
   cwd?: string;
@@ -56,6 +59,12 @@ function createDefaultDeps(cwd: string): PermissionRequestDeps {
 
 export async function permissionRequestHook(input: HookInput, deps?: PermissionRequestDeps): Promise<HookOutput> {
   const cwd = input.cwd || process.cwd();
+
+  // Exit early if cc-track not configured or autoflow not enabled
+  if (!isCcTrackConfigured(cwd) || !isHookEnabled('autoflow', undefined)) {
+    return { continue: true };
+  }
+
   const { readState } = deps || createDefaultDeps(cwd);
   const state = readState();
 

--- a/hooks/permission-request.ts
+++ b/hooks/permission-request.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { isCcTrackConfigured, isHookEnabled } from '../skills/cc-track-tools/lib/config';
+import { isAutoflowEnabled } from '../skills/cc-track-tools/lib/config';
 
 export interface HookInput {
   cwd?: string;
@@ -61,7 +61,7 @@ export async function permissionRequestHook(input: HookInput, deps?: PermissionR
   const cwd = input.cwd || process.cwd();
 
   // Exit early if cc-track not configured or autoflow not enabled
-  if (!isCcTrackConfigured(cwd) || !isHookEnabled('autoflow', undefined)) {
+  if (!isAutoflowEnabled()) {
     return { continue: true };
   }
 

--- a/hooks/stop.ts
+++ b/hooks/stop.ts
@@ -3,11 +3,14 @@
  * Stop Hook - Evaluates if Claude should continue in autoflow mode
  *
  * Uses battle-tested evaluation prompt from double-shot-latte project
- * with 3 continuations per 5-minute window throttling.
+ * with configurable throttling (default: 3 continuations per 5-minute window).
+ *
+ * IMPORTANT: Autoflow must be enabled in track.config.json to function.
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { getConfig, isCcTrackConfigured, isHookEnabled } from '../skills/cc-track-tools/lib/config';
 import { createLogger } from '../skills/cc-track-tools/lib/logger';
 
 export interface HookInput {
@@ -197,6 +200,12 @@ function createDefaultDeps(cwd: string): StopHookDeps {
 
 export async function stopHook(input: HookInput, deps?: StopHookDeps): Promise<StopHookResult> {
   const cwd = input.cwd || process.cwd();
+
+  // Exit early if cc-track not configured or autoflow not enabled
+  if (!isCcTrackConfigured(cwd) || !isHookEnabled('autoflow', undefined)) {
+    return { action: 'allow' };
+  }
+
   const { readState, writeState, readTranscript, evaluate, now } = deps || createDefaultDeps(cwd);
 
   const state = readState();
@@ -206,7 +215,14 @@ export async function stopHook(input: HookInput, deps?: StopHookDeps): Promise<S
     return { action: 'allow' };
   }
 
-  // Autoflow is active - check throttling (3 per 5-minute window)
+  // Get throttle config (with defaults)
+  const config = getConfig();
+  const autoflowConfig = config.features?.autoflow || {};
+  const throttleLimit = (autoflowConfig as { throttle_limit?: number }).throttle_limit || MAX_CONTINUES_PER_WINDOW;
+  const windowDurationMs =
+    ((autoflowConfig as { window_duration_minutes?: number }).window_duration_minutes || 5) * 60 * 1000;
+
+  // Autoflow is active - check throttling
   const currentTime = now();
   const windowStart = state.windowStart ? new Date(state.windowStart).getTime() : currentTime;
   const windowElapsed = currentTime - windowStart;
@@ -214,19 +230,19 @@ export async function stopHook(input: HookInput, deps?: StopHookDeps): Promise<S
   let continueCount = state.continueCount || 0;
 
   // Reset window if expired
-  if (windowElapsed >= WINDOW_DURATION_MS) {
+  if (windowElapsed >= windowDurationMs) {
     continueCount = 0;
   }
 
   // Check if we've exceeded the limit
-  if (continueCount >= MAX_CONTINUES_PER_WINDOW) {
+  if (continueCount >= throttleLimit) {
     // Deactivate autoflow due to throttle limit
     const updatedState = { ...state, active: false };
     writeState(updatedState);
 
     return {
       action: 'throttle',
-      message: `⚠️  Autoflow throttle limit reached\n\nClaude has continued ${MAX_CONTINUES_PER_WINDOW} times in the last 5 minutes.\nThis suggests it may be stuck in a loop.\n\nAutoflow mode has been deactivated. Please review the situation.`,
+      message: `⚠️  Autoflow throttle limit reached\n\nClaude has continued ${throttleLimit} times in the last ${(autoflowConfig as { window_duration_minutes?: number }).window_duration_minutes || 5} minutes.\nThis suggests it may be stuck in a loop.\n\nAutoflow mode has been deactivated. Please review the situation.`,
       updatedState,
     };
   }

--- a/hooks/stop.ts
+++ b/hooks/stop.ts
@@ -10,7 +10,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getConfig, isCcTrackConfigured, isHookEnabled } from '../skills/cc-track-tools/lib/config';
+import { getAutoflowConfig, isAutoflowEnabled } from '../skills/cc-track-tools/lib/config';
 import { createLogger } from '../skills/cc-track-tools/lib/logger';
 
 export interface HookInput {
@@ -202,7 +202,7 @@ export async function stopHook(input: HookInput, deps?: StopHookDeps): Promise<S
   const cwd = input.cwd || process.cwd();
 
   // Exit early if cc-track not configured or autoflow not enabled
-  if (!isCcTrackConfigured(cwd) || !isHookEnabled('autoflow', undefined)) {
+  if (!isAutoflowEnabled()) {
     return { action: 'allow' };
   }
 
@@ -216,11 +216,10 @@ export async function stopHook(input: HookInput, deps?: StopHookDeps): Promise<S
   }
 
   // Get throttle config (with defaults)
-  const config = getConfig();
-  const autoflowConfig = config.features?.autoflow || {};
-  const throttleLimit = (autoflowConfig as { throttle_limit?: number }).throttle_limit || MAX_CONTINUES_PER_WINDOW;
-  const windowDurationMs =
-    ((autoflowConfig as { window_duration_minutes?: number }).window_duration_minutes || 5) * 60 * 1000;
+  const autoflowConfig = getAutoflowConfig();
+  const throttleLimit = autoflowConfig?.throttle_limit ?? MAX_CONTINUES_PER_WINDOW;
+  const windowDurationMinutes = autoflowConfig?.window_duration_minutes ?? 5;
+  const windowDurationMs = windowDurationMinutes * 60 * 1000;
 
   // Autoflow is active - check throttling
   const currentTime = now();
@@ -242,7 +241,7 @@ export async function stopHook(input: HookInput, deps?: StopHookDeps): Promise<S
 
     return {
       action: 'throttle',
-      message: `⚠️  Autoflow throttle limit reached\n\nClaude has continued ${throttleLimit} times in the last ${(autoflowConfig as { window_duration_minutes?: number }).window_duration_minutes || 5} minutes.\nThis suggests it may be stuck in a loop.\n\nAutoflow mode has been deactivated. Please review the situation.`,
+      message: `⚠️  Autoflow throttle limit reached\n\nClaude has continued ${throttleLimit} times in the last ${windowDurationMinutes} minutes.\nThis suggests it may be stuck in a loop.\n\nAutoflow mode has been deactivated. Please review the situation.`,
       updatedState,
     };
   }

--- a/hooks/user-message.ts
+++ b/hooks/user-message.ts
@@ -7,10 +7,13 @@
  *
  * Activation: Include "autoflow" in message (not negated)
  * Deactivation: Any message without "autoflow" (or with negation)
+ *
+ * IMPORTANT: Autoflow must be enabled in track.config.json to function.
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { isCcTrackConfigured, isHookEnabled } from '../skills/cc-track-tools/lib/config';
 
 export interface HookInput {
   prompt?: string;
@@ -87,6 +90,12 @@ export function shouldActivate(message: string): boolean {
 export async function userMessageHook(input: HookInput, deps?: UserMessageDeps): Promise<HookOutput> {
   const message = input.prompt || '';
   const cwd = input.cwd || process.cwd();
+
+  // Exit early if cc-track not configured or autoflow not enabled
+  if (!isCcTrackConfigured(cwd) || !isHookEnabled('autoflow', undefined)) {
+    return { continue: true };
+  }
+
   const { readState, writeState } = deps || createDefaultDeps(cwd);
 
   const currentState = readState();

--- a/hooks/user-message.ts
+++ b/hooks/user-message.ts
@@ -13,7 +13,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { isCcTrackConfigured, isHookEnabled } from '../skills/cc-track-tools/lib/config';
+import { isAutoflowEnabled } from '../skills/cc-track-tools/lib/config';
 
 export interface HookInput {
   prompt?: string;
@@ -92,7 +92,7 @@ export async function userMessageHook(input: HookInput, deps?: UserMessageDeps):
   const cwd = input.cwd || process.cwd();
 
   // Exit early if cc-track not configured or autoflow not enabled
-  if (!isCcTrackConfigured(cwd) || !isHookEnabled('autoflow', undefined)) {
+  if (!isAutoflowEnabled()) {
     return { continue: true };
   }
 

--- a/skills/cc-track-tools/lib/config.ts
+++ b/skills/cc-track-tools/lib/config.ts
@@ -368,3 +368,12 @@ export function getTestConfig(configPath?: string): ValidationConfig | null {
 
   return testConfig;
 }
+
+export function getAutoflowConfig(configPath?: string): AutoflowConfig | null {
+  const config = getConfig(configPath);
+  return (config.features?.autoflow as AutoflowConfig) || null;
+}
+
+export function isAutoflowEnabled(configPath?: string): boolean {
+  return isCcTrackConfigured() && isHookEnabled('autoflow', configPath);
+}

--- a/skills/cc-track-tools/lib/config.ts
+++ b/skills/cc-track-tools/lib/config.ts
@@ -41,6 +41,11 @@ export interface StatuslineConfig extends HookConfig {
   show_repo?: boolean;
 }
 
+export interface AutoflowConfig extends HookConfig {
+  throttle_limit?: number;
+  window_duration_minutes?: number;
+}
+
 interface GitConfig {
   defaultBranch?: string;
   description?: string;
@@ -60,7 +65,7 @@ interface InternalConfig {
     [key: string]: HookConfig | EditValidationConfig;
   };
   features: {
-    [key: string]: HookConfig | CodeReviewConfig | StatuslineConfig;
+    [key: string]: HookConfig | CodeReviewConfig | StatuslineConfig | AutoflowConfig;
   };
   git?: GitConfig;
   logging?: LoggingConfig;
@@ -148,6 +153,12 @@ const DEFAULT_CONFIG: InternalConfig = {
       enabled: false,
       description: 'Run comprehensive code review before task completion',
       tool: 'claude' as const,
+    },
+    autoflow: {
+      enabled: false,
+      description: 'Autonomous operation mode - activates per-message when "autoflow" keyword is used',
+      throttle_limit: 3,
+      window_duration_minutes: 5,
     },
   },
 };


### PR DESCRIPTION
## Summary
- Autoflow is now **disabled by default** and must be explicitly enabled in track.config.json
- Added configurable `throttle_limit` and `window_duration_minutes` options
- All autoflow hooks (user-message, permission-request, stop) now check config before running

## Problem
Autoflow was documented as having config options that didn't exist. The implementation had hardcoded values and was always active when the plugin was installed.

## Solution
1. Added `autoflow` to features config with `enabled: false` default
2. Added `AutoflowConfig` interface with `throttle_limit` and `window_duration_minutes`
3. Updated all three autoflow hooks to check `isCcTrackConfigured()` and `isHookEnabled('autoflow')` before doing anything
4. Updated stop hook to read throttle values from config instead of hardcoded constants
5. Fixed config-track.md documentation to accurately describe the feature

## Breaking Change
Autoflow is now disabled by default. Users who want autoflow must add this to their track.config.json:
```json
"features": {
  "autoflow": {
    "enabled": true
  }
}
```

## Test plan
- [x] All 441 tests pass
- [x] TypeScript check passes  
- [x] Biome lint passes
- [x] Knip check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)