### PR TITLE
fix: use ${CLAUDE_PLUGIN_ROOT} for template paths in workflow commands

### DIFF
--- a/commands/constitution.md
+++ b/commands/constitution.md
@@ -84,7 +84,7 @@ Any specific technical constraints?
 
 ## Phase 2: Generate Constitution
 
-Use `templates/constitution-template.md` and customize:
+Read template from `${CLAUDE_PLUGIN_ROOT}/templates/constitution-template.md` and customize:
 
 ### Core Principles Section
 Based on project type and complexity:

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -279,7 +279,7 @@ For each endpoint from spec:
 Save to `contracts/` directory.
 
 ### Write Plan Document
-Use `templates/plan-template.md`:
+Read template from `${CLAUDE_PLUGIN_ROOT}/templates/plan-template.md`:
 - Summary
 - Technical Context (from above)
 - Constitution Check results

--- a/commands/specify.md
+++ b/commands/specify.md
@@ -114,7 +114,7 @@ If needed, spawn 1-2 Explore agents (parallel via Task tool). Results inform you
 
 Once you have **complete** understanding (all taxonomy areas covered, no remaining ambiguities):
 
-1. **Read** `templates/spec-template.md`
+1. **Read** `${CLAUDE_PLUGIN_ROOT}/templates/spec-template.md`
 2. **Fill in** all sections from gathered information
 3. **Write** to `.cc-track/specs/{taskId}-{featureName}/spec.md`
 

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -98,7 +98,7 @@ For phases requiring a waiver, mark them `[TDD WAIVER REQUESTED]` in the initial
 
 ## Step 2: Generate tasks.md
 
-Use `templates/tasks-template.md` as the base structure.
+Read template from `${CLAUDE_PLUGIN_ROOT}/templates/tasks-template.md` as the base structure.
 
 ### Structure
 
@@ -229,7 +229,7 @@ Dispatch subagents one at a time in TDD order:
 
 ### For Parallel Phases and Dependency Enforcement
 
-See `templates/tasks-template.md` for the orchestration patterns (pipeline flow, polling fallback, dependency rules). These are included in the generated tasks.md and followed during execution.
+See `${CLAUDE_PLUGIN_ROOT}/templates/tasks-template.md` for the orchestration patterns (pipeline flow, polling fallback, dependency rules). These are included in the generated tasks.md and followed during execution.
 
 ### For Waived Phases
 


### PR DESCRIPTION
## Summary
- Update template references in workflow commands to use full plugin root path
- Fixes template loading when plugin is installed (not just running from source)

## Changes
- `commands/constitution.md` - constitution-template.md path
- `commands/plan.md` - plan-template.md path
- `commands/specify.md` - spec-template.md path
- `commands/tasks.md` - tasks-template.md paths (2 references)

## Test plan
- [ ] Verify `/cc-track:specify` loads spec-template.md correctly
- [ ] Verify `/cc-track:plan` loads plan-template.md correctly
- [ ] Verify `/cc-track:tasks` loads tasks-template.md correctly
- [ ] Verify `/cc-track:constitution` loads constitution-template.md correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)