### PR TITLE
fix: prevent orchestrator context overflow from TaskOutput polling

### DIFF
--- a/commands/spotless.md
+++ b/commands/spotless.md
@@ -209,7 +209,7 @@ You are investigating recent changes in {area_name} for dead code artifacts.
 Save your report to: .cc-track/analysis/spotless/area_reports/{area_name}_report.md
 ```
 
-**Wait** for all investigation subagents to complete.
+Post a status message: "Waiting for investigation subagents to complete." and **STOP**. Do NOT call TaskOutput to poll. The system will wake you when each subagent completes.
 
 ---
 
@@ -251,7 +251,7 @@ You are validating a finding from dead code analysis.
 Save to: .cc-track/analysis/spotless/validations/{finding_id}_validation.md
 ```
 
-**Wait** for all validation subagents to complete.
+Post a status message: "Waiting for validation subagents to complete." and **STOP**. Do NOT call TaskOutput to poll. The system will wake you when each subagent completes.
 
 ---
 

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -293,9 +293,9 @@ TaskUpdate: "P3: Tests" addBlockedBy: ["P3: Stub"]
 
 **Use `TaskList`** to see what's unblocked and ready to dispatch. The native system enforces dependencies automatically - you can't accidentally start Tests before Stub completes.
 
-**Pipeline flow**: As each step completes, its dependents become unblocked. Dispatch newly-unblocked tasks immediately for maximum parallelism.
+**Pipeline flow**: Dispatch all unblocked tasks, post a status message ("Waiting for task completion."), and **STOP**. Do NOT call TaskOutput to watch or poll subagents - this dumps their entire working context into the orchestrator's context window, causing rapid context overflow. When a subagent completes, the system wakes the orchestrator automatically. At that point, update task status, check `TaskList` for newly unblocked tasks, dispatch them, and wait again.
 
-See `${CLAUDE_PLUGIN_ROOT}/templates/tasks-template.md` for additional orchestration patterns (polling fallback, dependency diagrams). These are included in the generated tasks.md.
+See `${CLAUDE_PLUGIN_ROOT}/templates/tasks-template.md` for additional orchestration patterns (dependency diagrams). These are included in the generated tasks.md.
 
 ### For Waived Phases
 

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -176,15 +176,15 @@ When multiple phases are marked [P], use **pipeline flow** with native task coor
 
 1. **Create all native tasks upfront** with `blockedBy` dependencies (see Setup above)
 2. **Use `TaskList`** to see all unblocked tasks ready to dispatch
-3. **Dispatch** all unblocked stub writers with `run_in_background: true` in a single message
-4. **Post status** to user: "Dispatched stub writers for Phases X, Y, Z."
-5. **Orchestration loop**:
+3. **Dispatch** all unblocked stub writers in a single message
+4. **Post status** to user: "Dispatched stub writers for Phases X, Y, Z. Waiting for task completion."
+5. **STOP and wait** - Do NOT call TaskOutput or poll agents. When a subagent completes, the system will wake you automatically with its results. At that point:
+   - `TaskUpdate` the completed step's status to completed
    - `TaskList` to find newly unblocked tasks (e.g., Tests for completed Stubs)
-   - Dispatch unblocked tasks, `TaskUpdate` status to in_progress
-   - As agents complete, `TaskUpdate` status to completed
-   - Repeat until all tasks complete
+   - Dispatch any newly unblocked tasks, `TaskUpdate` their status to in_progress
+   - Post another status message and wait again if tasks remain
 
-The native `blockedBy` system automatically tracks what's ready - no manual dependency checking needed. As each step completes, its dependents become unblocked and appear in `TaskList`.
+**CRITICAL**: Never use TaskOutput to watch subagent progress. This dumps the subagent's entire working context into the orchestrator's context window, causing rapid context overflow. The notification system handles completion automatically.
 
 ### Dependency Enforcement
 


### PR DESCRIPTION
## Summary
- Updated orchestration instructions in `commands/tasks.md`, `commands/spotless.md`, and `templates/tasks-template.md` to stop Claude from using TaskOutput to watch subagent progress
- Orchestrator now posts a status message and STOPs; the notification system wakes it when subagents complete
- Prevents subagent working context from being dumped into the orchestrator's context window, which was causing rapid context overflow

## Test plan
- [ ] Run `/cc-track:tasks` with parallel phases and verify orchestrator posts status and waits without calling TaskOutput
- [ ] Run `/cc-track:spotless` and verify investigation/validation subagents complete via notification, not polling
- [ ] Verify foreground parallel commands (prepare-completion, spec-review) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)