### PR TITLE
fix: register TDD workflow agents in plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,7 +16,11 @@
   ],
   "agents": [
     "./agents/researcher.md",
+    "./agents/stub-writer.md",
     "./agents/test-generation.md",
+    "./agents/implementer.md",
+    "./agents/validator.md",
+    "./agents/issue-scorer.md",
     "./agents/spec-compliance-reviewer.md",
     "./agents/plan-adherence-reviewer.md",
     "./agents/task-completion-reviewer.md",

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -191,6 +191,14 @@ Phase 4 ──┘
 
 ## Orchestration Instructions
 
+**MANDATORY: Use specialized subagent types.** Every Task tool call during orchestration MUST use the correct `subagent_type` parameter:
+- **Stub** steps → `subagent_type: stub-writer`
+- **Tests** steps → `subagent_type: test-generation`
+- **Implement** steps → `subagent_type: implementer`
+- **Validate** steps → `subagent_type: validator`
+
+Do NOT use `subagent_type: general-purpose` or omit `subagent_type`. The specialized agents have tailored system prompts, tool access, and behavioral constraints that general-purpose agents lack.
+
 When the user approves this task breakdown and says to begin implementation:
 
 ### Real-Time Task Coordination (Native Task System)

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -124,6 +124,14 @@ Document which phases can run in parallel and which have dependencies.
 
 ## Orchestration Instructions
 
+**MANDATORY: Use specialized subagent types.** Every Task tool call during orchestration MUST use the correct `subagent_type` parameter:
+- **Stub** steps → `subagent_type=stub-writer`
+- **Tests** steps → `subagent_type=test-generation`
+- **Implement** steps → `subagent_type=implementer`
+- **Validate** steps → `subagent_type=validator`
+
+Do NOT use `subagent_type=general-purpose` or omit `subagent_type`. The specialized agents have tailored system prompts, tool access, and behavioral constraints that general-purpose agents lack.
+
 ### Setup: Create Native Tasks
 
 Before starting implementation, create native tasks for all steps with dependencies:
@@ -176,7 +184,7 @@ When multiple phases are marked [P], use **pipeline flow** with native task coor
 
 1. **Create all native tasks upfront** with `blockedBy` dependencies (see Setup above)
 2. **Use `TaskList`** to see all unblocked tasks ready to dispatch
-3. **Dispatch** all unblocked stub writers in a single message
+3. **Dispatch** all unblocked tasks in a single message using the correct `subagent_type` for each (see table above)
 4. **Post status** to user: "Dispatched stub writers for Phases X, Y, Z. Waiting for task completion."
 5. **STOP and wait** - Do NOT call TaskOutput or poll agents. When a subagent completes, the system will wake you automatically with its results. At that point:
    - `TaskUpdate` the completed step's status to completed


### PR DESCRIPTION
## Summary
- Adds `stub-writer`, `implementer`, `validator`, and `issue-scorer` to `.claude-plugin/plugin.json`
- Without these entries the agent files exist on disk but Claude Code never loads them, so the TDD orchestration (`/cc-track:tasks`) and issue triage (`/cc-track:prepare-completion` → `/cc-track:fix-issues`) workflows cannot spawn their required subagents

## Test plan
- [ ] Reload the plugin and confirm all 14 agents in `agents/` are available
- [ ] Run `/cc-track:tasks` on a spec and verify the stub → test → implement → validate chain spawns correctly
- [ ] Run `/cc-track:prepare-completion` with >1 findings and verify `issue-scorer` is invoked