### PR TITLE
feat: integrate Impeccable design-skill pack guidance into workflow

### DIFF
--- a/commands/plan.md
+++ b/commands/plan.md
@@ -13,6 +13,7 @@ allowed-tools: Read, Edit, Write, Glob, Grep, Bash(mkdir:*), Bash(ls:*), Bash(te
 
 - Active spec directory: !`ls -1 .cc-track/specs/ 2>/dev/null | tail -1`
 - Constitution exists: !`ls .cc-track/constitution.md 2>/dev/null | head -1`
+- Design system (DESIGN.md) exists: !`ls DESIGN.md 2>/dev/null | head -1`
 
 ---
 
@@ -197,6 +198,7 @@ This saves your context for design work while getting thorough research.
 
 ### Document Decisions
 Create `research.md`:
+
 ```markdown
 # Research: [Feature Name]
 
@@ -213,6 +215,41 @@ Create `research.md`:
 ### Decision: SQLite for Storage
 ...
 ```
+
+---
+
+## Step 4.5: Design System Check (Optional)
+
+**Skip this step entirely if `DESIGN.md` does not exist at the project root** (see Current Context block).
+
+**Skip this step if the feature has no UI surface** (pure backend, library, CLI, data pipeline, etc.).
+
+**If `DESIGN.md` exists AND the feature touches UI**:
+
+The project uses [Impeccable](https://impeccable.style/) and/or the [DESIGN.md](https://github.com/google-labs-code/design.md) format for its design system. Before drafting the technical plan, surface this to the user:
+
+```
+🎨 This feature touches UI and the project has a DESIGN.md.
+
+Before I design the implementation, you may want to run one of:
+  - /impeccable craft  — for new surfaces, full design-aware composition
+  - /impeccable shape  — to tighten an existing rough shape against the design system
+
+This produces design decisions that should inform plan.md (component choices,
+layout, tokens to reference). Then I'll write plan.md with explicit references
+to DESIGN.md tokens rather than reinventing values.
+
+Options:
+  A) Pause here so you can run /impeccable craft (or /shape)
+  B) Proceed to plan.md now — I'll reference DESIGN.md tokens directly
+  C) Skip — design system not relevant to this feature
+```
+
+**If user picks A**: Stop and wait for them to return with Impeccable's output.
+**If user picks B**: Continue to Step 5, but read `DESIGN.md` first and reference its tokens (colors, typography, spacing, components) explicitly in `plan.md`.
+**If user picks C**: Continue to Step 5 normally.
+
+This step is purely a suggestion — never block on it.
 
 ---
 

--- a/commands/prepare-completion.md
+++ b/commands/prepare-completion.md
@@ -11,6 +11,8 @@ Run validation checks and multi-agent spec-focused code review to ensure the tas
 
 - Current branch: !`git branch --show-current`
 - Changes to review: !`git diff --stat`
+- Design system (DESIGN.md) exists: !`ls DESIGN.md 2>/dev/null | head -1`
+- UI files in diff: !`git diff main --name-only 2>/dev/null | grep -E '\.(tsx|jsx|vue|svelte|astro|css|scss|sass|less|html)$' | head -20`
 
 ## Step 1: Run Validation Script
 
@@ -180,6 +182,39 @@ After all scorers complete:
 ## Filtered Out (Score < 50)
 - [N] issues were filtered as unverified or false positives
 ```
+
+## Step 6.5: UI Design Check (Optional)
+
+**Skip this step entirely if `DESIGN.md` does not exist at the project root** (see Current Context block).
+
+**Skip this step if no UI files appear in the diff** (Current Context shows the matched files).
+
+**If `DESIGN.md` exists AND UI files were modified**:
+
+The project uses [Impeccable](https://impeccable.style/) and/or the [DESIGN.md](https://github.com/google-labs-code/design.md) format. Surface this advisory to the user (in addition to whatever Step 7 would say):
+
+```
+🎨 UI changes detected with a DESIGN.md present.
+
+Before running /cc-track:complete-task, consider running:
+  - /impeccable audit    — technical UI quality (a11y, performance, theming,
+                            responsive, anti-patterns) scored P0–P3
+  - /impeccable critique — subjective design quality ("does this feel right")
+
+Findings map onto cc-track's triage:
+  - P0 (blocks release)  → Fix
+  - P1 (this sprint)     → Fix or Defer
+  - P2 (next cycle)      → Defer
+  - P3 (polish)          → Dismiss/Defer
+
+Re-run /cc-track:prepare-completion afterwards if /impeccable audit surfaces
+significant new issues. Skip this if the UI changes are trivial (typo,
+copy edit, etc.).
+```
+
+This is advisory — it does **not** block Step 7 routing. The user decides whether to run the audit before or after the existing review agents' findings.
+
+---
 
 ## Step 7: Route Based on Issue Count
 

--- a/commands/setup-cc-track.md
+++ b/commands/setup-cc-track.md
@@ -397,6 +397,11 @@ After setup completes:
 2. **Next steps guidance**:
    - "Setup complete! 🚅"
    - "Optional: Run `/cc-track:constitution` to set up project guardrails and architectural constraints"
+   - **If the project type from step 1 is a web app, native UI, or otherwise renders a UI**, also suggest:
+     - "Optional: For UI projects, consider installing [Impeccable](https://impeccable.style/) — a design-fluency skill pack that produces a `DESIGN.md` (Google Labs' portable design-system format) and `PRODUCT.md` for AI agents to follow. It pairs cleanly with cc-track."
+     - "  Install: `npx skills add pbakaus/impeccable`"
+     - "  Then run `/impeccable teach` (creates PRODUCT.md) and `/impeccable document` (creates DESIGN.md from existing UI code), or `/impeccable document --seed` if you have no UI code yet."
+     - "  See `${CLAUDE_PLUGIN_ROOT}/docs/integrations/impeccable.md` for how it slots into the cc-track workflow (planning, audit, completion)."
    - "Try creating your first spec: `/cc-track:specify \"your feature idea\"`"
    - "Configure anytime with: `/config-track`"
    - If statusline configured: "⚠️ Restart Claude Code to see the custom statusline"

--- a/docs/integrations/impeccable.md
+++ b/docs/integrations/impeccable.md
@@ -1,0 +1,182 @@
+# Using Impeccable Alongside cc-track
+
+[Impeccable](https://impeccable.style/) is a design-fluency skill pack for AI coding harnesses (Claude Code, Cursor, Codex, Gemini). It pairs naturally with cc-track on UI-heavy projects: cc-track owns the workflow (specs, plans, validation, completion), Impeccable owns the design vocabulary (typography, color, layout, motion, anti-patterns) and produces the persistent design context that AI agents follow.
+
+This guide assumes you already have cc-track set up. If not, run `/cc-track:setup-cc-track` first.
+
+---
+
+## When you want this integration
+
+You want Impeccable if **any** of the following apply:
+
+- The project renders a UI (web, native, or otherwise) and you care about visual consistency
+- Claude has been improvising its own design system on the fly across sessions
+- You want AI-generated UI to stay on brand without re-explaining brand rules every task
+- You want a structured design audit (a11y, performance, theming, responsive, anti-patterns) as part of completion checks
+
+For pure backend, library, or CLI projects, skip this — there's nothing for Impeccable to anchor to.
+
+---
+
+## What Impeccable produces
+
+After installation, Impeccable generates two files at the project root:
+
+| File | What it is | Standard |
+|---|---|---|
+| `PRODUCT.md` | Strategy: register (brand vs product), audience, brand personality, anti-references, principles | Impeccable-specific |
+| `DESIGN.md` | Visual system: colors, typography, elevation, components, do's/don'ts | Google Labs' [DESIGN.md](https://github.com/google-labs-code/design.md) format (portable) |
+
+`DESIGN.md` is the artifact other tools can read. `PRODUCT.md` is Impeccable's own control surface (most importantly, the `## Register` field which switches Impeccable's command behavior between `brand` and `product` defaults).
+
+---
+
+## Setup (one-time, after cc-track is initialized)
+
+### 1. Install the Impeccable skill
+
+```bash
+npx skills add pbakaus/impeccable
+```
+
+This auto-detects your AI harness (Claude Code in our case) and drops the skill into the right location. See the [Impeccable getting-started guide](https://impeccable.style/tutorials/getting-started/) for manual install or other harnesses.
+
+### 2. Generate `PRODUCT.md`
+
+Run inside Claude Code:
+
+```
+/impeccable teach
+```
+
+Impeccable interviews you about the product (audience, register, personality, anti-references) and writes `PRODUCT.md` at the project root.
+
+### 3. Generate `DESIGN.md`
+
+Pick the variant that matches where you are:
+
+- **Brownfield** (UI code already exists, you want Impeccable to extract its design system):
+  ```
+  /impeccable document
+  ```
+- **Greenfield** (no UI code yet, or you want to scaffold a fresh design system):
+  ```
+  /impeccable document --seed
+  ```
+  This asks five strategic questions and writes a scaffold marked with `<!-- SEED -->` comments. Re-run without `--seed` once real tokens land in code.
+
+Both variants write `DESIGN.md` (and a `DESIGN.json` sidecar) at the project root.
+
+### 4. Wire `DESIGN.md` into persistent context
+
+Add `@DESIGN.md` (and optionally `@PRODUCT.md`) to the top of `CLAUDE.md` so Claude Code loads them on every session, the same way cc-track imports `system_patterns.md` and `decision_log.md`. Example:
+
+```markdown
+# Project: my-app
+
+## Active Task
+no_active_task
+
+## Design System
+@DESIGN.md
+
+## Product Strategy
+@PRODUCT.md
+
+## Product Vision
+@.cc-track/product_context.md
+
+...
+```
+
+`DESIGN.md` then informs every Claude turn in the project, not just Impeccable's own commands.
+
+---
+
+## Where Impeccable plugs into the cc-track workflow
+
+cc-track's stages don't change. Impeccable's commands become discretionary tools you reach for at specific moments.
+
+### During `/cc-track:specify`
+
+No change. Specs stay tech-agnostic — describe UI requirements in user-facing terms ("a clear empty state", "primary action prominent") rather than in design-token terms.
+
+### During `/cc-track:plan`
+
+For UI-touching features, before drafting `plan.md`, run one of:
+
+- **`/impeccable craft`** — design-aware composition for a new surface
+- **`/impeccable shape`** — when you have a rough shape and want it tightened against the design system
+
+The output informs `plan.md`'s component, layout, and styling decisions. `plan.md` should reference DESIGN.md tokens (e.g., "uses `--color-primary`, `--space-4`") rather than reinventing values.
+
+If `DESIGN.md` exists at the project root and the spec touches UI, the `/cc-track:plan` command will surface this suggestion automatically.
+
+### During implementation
+
+Reach for Impeccable's refinement commands as needed:
+
+| Concern | Command |
+|---|---|
+| Typography | `/impeccable typeset` |
+| Color | `/impeccable colorize` |
+| Layout | `/impeccable layout` |
+| Motion | `/impeccable animate` |
+| Polish pass | `/impeccable polish` |
+| Reduce visual noise | `/impeccable quieter` / `/distill` |
+| Increase emphasis | `/impeccable bolder` / `/overdrive` |
+
+These are tools, not steps — use them when a specific concern arises.
+
+### During `/cc-track:prepare-completion`
+
+For UI-touching changes, after validation passes, run both:
+
+- **`/impeccable audit`** — technical quality (a11y, performance, theming, responsive, anti-patterns) scored 0–4 per dimension with **P0–P3 severity**
+- **`/impeccable critique`** — subjective design quality ("does this feel right")
+
+Findings flow into cc-track's existing `/cc-track:fix-issues` triage naturally — Impeccable's P0/P1/P2/P3 maps directly onto Fix / Defer / Dismiss / Discuss decisions, with **P0 = blocks release** matching cc-track's score-100 issues. No new triage UX needed.
+
+If `DESIGN.md` exists at the project root and the changed files include UI assets, the `/cc-track:prepare-completion` command will surface this suggestion automatically.
+
+---
+
+## File-layout reference
+
+After integration, expect the following at project root:
+
+```
+my-project/
+├── CLAUDE.md                  # cc-track + @DESIGN.md / @PRODUCT.md imports
+├── DESIGN.md                  # Impeccable / Google Stitch format (portable)
+├── DESIGN.json                # Impeccable sidecar (machine-readable tokens)
+├── PRODUCT.md                 # Impeccable-specific strategy file
+├── .cc-track/                 # cc-track context, specs, config
+│   ├── specs/
+│   ├── product_context.md
+│   ├── decision_log.md
+│   └── ...
+├── .claude/                   # Impeccable skill files land here per harness
+│   └── skills/impeccable/...
+└── (your code)
+```
+
+cc-track and Impeccable own different directories — there is no overlap or conflict. The only shared touchpoint is `CLAUDE.md` (where you import both sets of context).
+
+---
+
+## Going further
+
+- The standalone `npx impeccable detect <path|url>` CLI runs anti-pattern detection non-interactively. You could wire it into a pre-commit hook or CI step independent of Claude.
+- If you stop using Impeccable, `DESIGN.md` remains valuable — it's a portable format other AI tools (Cursor, Copilot, Stitch) understand. `PRODUCT.md` is Impeccable-coupled and would need re-expression elsewhere.
+
+## Sources
+
+- [Impeccable docs](https://impeccable.style/docs/impeccable/)
+- [Impeccable: /teach](https://impeccable.style/docs/teach/)
+- [Impeccable: /document](https://impeccable.style/docs/document/)
+- [Impeccable: /audit](https://impeccable.style/docs/audit/)
+- [Impeccable: getting started](https://impeccable.style/tutorials/getting-started/)
+- [Impeccable on GitHub](https://github.com/pbakaus/impeccable)
+- [DESIGN.md specification (Google Labs)](https://github.com/google-labs-code/design.md)


### PR DESCRIPTION
Adds level-1 documentation and level-2 conditional guidance for using
Impeccable (https://impeccable.style/) alongside cc-track on UI projects.

- New docs/integrations/impeccable.md integration guide covering install
  (npx skills add pbakaus/impeccable), bootstrap (/impeccable teach for
  PRODUCT.md, /impeccable document or --seed for DESIGN.md), CLAUDE.md
  wiring, and where Impeccable's commands plug into the cc-track workflow.

- setup-cc-track surfaces an optional Impeccable install suggestion in the
  Final Steps for projects that render a UI.

- /cc-track:plan adds a "Step 4.5: Design System Check" that surfaces only
  when DESIGN.md exists at project root and the feature is UI-touching,
  suggesting /impeccable craft or /shape before drafting plan.md.

- /cc-track:prepare-completion adds a "Step 6.5: UI Design Check" that
  surfaces only when DESIGN.md exists and UI files appear in the diff,
  suggesting /impeccable audit (P0-P3 maps onto /fix-issues triage) and
  /impeccable critique. Advisory only - does not gate Step 7 routing.

Both command-level checks are no-ops on non-UI projects (skip when no
DESIGN.md present). PRODUCT.md is Impeccable-specific; DESIGN.md follows
Google Labs' portable format.

https://claude.ai/code/session_01PPaAeiu1kP3jkNjELQs2xt